### PR TITLE
more specific tests for 'wait' parameter

### DIFF
--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -74,8 +74,8 @@ class JsInterval(Resource):
 var num=0;
 setInterval(function(){
     document.getElementById('num').innerHTML = num;
-    num += 1;
-}, 1);
+    num += 100;
+}, 100);
 </script>
 </body></html>
 """

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -50,7 +50,7 @@ class _RenderTest(_BaseRenderTest):
         r = self.request("url=http://localhost:8998/iframes&timeout=3")
         self.assertEqual(r.status_code, 200)
 
-    def test_wait(self):
+    def test_wait_works(self):
         r1 = self.request("url=http://localhost:8998/jsinterval")
         r2 = self.request("url=http://localhost:8998/jsinterval")
         r3 = self.request("url=http://localhost:8998/jsinterval&wait=0.2")
@@ -87,6 +87,11 @@ class RenderHtmlTest(_RenderTest):
         self.assertEqual(r.status_code, 200)
         self.assertTrue("Before" not in r.text)
         self.assertTrue("After" in r.text)
+
+    def test_wait_value(self):
+        r = self.request("url=http://localhost:8998/jsinterval&wait=0.5")
+        self.assertEqual(r.status_code, 200)
+        assert any(str(v) in r.text for v in [600, 500, 400]), r.text
 
 
 class RenderPngTest(_RenderTest):
@@ -248,7 +253,7 @@ class RenderJsonTest(_RenderTest):
                                           "title"])
         self.assertFieldsNotInResponse(res, ["childFrames", "html", "png"])
 
-    def test_wait(self):
+    def test_wait_works(self):
         # override parent's test to make it aware of render.json endpoint
         r1 = self.request({"url": "http://localhost:8998/jsinterval", 'html': 1})
         r2 = self.request({"url": "http://localhost:8998/jsinterval", 'html': 1})


### PR DESCRIPTION
See https://github.com/scrapinghub/splash/pull/22 for the discussion.

Other idea from #22 is to limit 'wait' to 10s. I haven't implemented it here (wait is still limited to 60s) - for example, there could be pages with decreasing counter that allows to do action after some time, and this time can be >10s. I don't know if it a common enough scenario. What do you think?
