### PR TITLE
[MRG] use single instances of QNetworkAccessManager and QNetworkDiskCache

### DIFF
--- a/splash/cache.py
+++ b/splash/cache.py
@@ -10,5 +10,5 @@ def construct(path=defaults.CACHE_PATH, size=defaults.CACHE_SIZE):
     cache = QNetworkDiskCache()
     cache.setCacheDirectory(path)
     cache.setMaximumCacheSize(size * 1024**2)
-    cache.cacheSize() # forces immediate initialization
+    cache.cacheSize()  # forces immediate initialization
     return cache

--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -2,14 +2,24 @@
 from __future__ import absolute_import
 import re
 from PyQt4.QtCore import QUrl
-from PyQt4.QtNetwork import QNetworkAccessManager
+from PyQt4.QtNetwork import QNetworkAccessManager, QNetworkProxyQuery
+from PyQt4.QtWebKit import QWebFrame
 from splash.utils import getarg
 
+
 class SplashQNetworkAccessManager(QNetworkAccessManager):
-    def __init__(self, *args, **kwargs):
-        super(SplashQNetworkAccessManager, self).__init__(*args, **kwargs)
+    """
+    This QNetworkAccessManager subclass enables "splash proxy factories"
+    support. Qt provides similar functionality via setProxyFactory method,
+    but standard QNetworkProxyFactory is not flexible enough.
+    """
+
+    def __init__(self):
+        super(SplashQNetworkAccessManager, self).__init__()
         self.sslErrors.connect(self._sslErrors)
         self.finished.connect(self._finished)
+
+        assert self.proxyFactory() is None, "Standard QNetworkProxyFactory is not supported"
 
     def _sslErrors(self, reply, errors):
         reply.ignoreSslErrors()
@@ -17,27 +27,64 @@ class SplashQNetworkAccessManager(QNetworkAccessManager):
     def _finished(self, reply):
         reply.deleteLater()
 
+    def createRequest(self, operation, request, outgoingData=None):
+        old_proxy = self.proxy()
 
-class FilteringQNetworkAccessManager(SplashQNetworkAccessManager):
+        splash_proxy_factory = self._getSplashProxyFactory(request)
+        if splash_proxy_factory:
+            proxy_query = QNetworkProxyQuery(request.url())
+            proxy = splash_proxy_factory.queryProxy(proxy_query)[0]
+            self.setProxy(proxy)
 
-    def __init__(self, request, allow_subdomains=True):
-        allowed_domains = getarg(request, "allowed_domains", None)
-        if allowed_domains is not None:
-            allowed_domains = allowed_domains.split(',')
-        self.host_re = self.get_host_regex(allowed_domains, allow_subdomains)
-        super(FilteringQNetworkAccessManager, self).__init__()
+        # this method is called createRequest, but in fact it creates a reply
+        reply = super(SplashQNetworkAccessManager, self).createRequest(
+            operation, request, outgoingData
+        )
 
-    def createRequest(self, QNetworkAccessManager_Operation, QNetworkRequest, QIODevice_device=None):
-        if not self.host_re.match(unicode(QNetworkRequest.url().host())):
-            # hack: set invalid URL
-            QNetworkRequest.setUrl(QUrl('forbidden://localhost/'))
-
-        # this method is called crateRequest, but in fact it creates a reply
-        reply = super(FilteringQNetworkAccessManager, self).createRequest(
-            QNetworkAccessManager_Operation, QNetworkRequest, QIODevice_device)
+        self.setProxy(old_proxy)
         return reply
 
-    def get_host_regex(self, allowed_domains, allow_subdomains):
+    def _getSplashRequest(self, request):
+        return self._getWebPageAttribute(request, 'splash_request')
+
+    def _getSplashProxyFactory(self, request):
+        return self._getWebPageAttribute(request, 'splash_proxy_factory')
+
+    def _getWebPageAttribute(self, request, attribute):
+        web_frame = request.originatingObject()
+        if isinstance(web_frame, QWebFrame):
+            return getattr(web_frame.page(), attribute, None)
+
+    def _drop_request(self, request):
+        # hack: set invalid URL
+        request.setUrl(QUrl('forbidden://localhost/'))
+
+
+class FilteringQNetworkAccessManager(SplashQNetworkAccessManager):
+    """
+    This SplashQNetworkAccessManager subclass enables request filtering
+    based on 'allowed_domains' GET parameter in original Splash request.
+    """
+    def __init__(self, allow_subdomains=True):
+        self.allow_subdomains = allow_subdomains
+        super(FilteringQNetworkAccessManager, self).__init__()
+
+    def createRequest(self, operation, request, outgoingData=None):
+        splash_request = self._getSplashRequest(request)
+        if splash_request:
+            allowed_domains = self._get_allowed_domains(splash_request)
+            host_re = self._get_host_regex(allowed_domains, self.allow_subdomains)
+            if not host_re.match(unicode(request.url().host())):
+                self._drop_request(request)
+
+        return super(FilteringQNetworkAccessManager, self).createRequest(operation, request, outgoingData)
+
+    def _get_allowed_domains(self, splash_request):
+        allowed_domains = getarg(splash_request, "allowed_domains", None)
+        if allowed_domains is not None:
+            return allowed_domains.split(',')
+
+    def _get_host_regex(self, allowed_domains, allow_subdomains):
         """Override this method to implement a different offsite policy"""
         if not allowed_domains:
             return re.compile('')  # allow all by default

--- a/splash/tests/test_proxy.py
+++ b/splash/tests/test_proxy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import unittest
-from splash.proxy import BlackWhiteQNetworkProxyFactory, SplashQNetworkProxyFactory
+from splash.proxy import BlackWhiteSplashProxyFactory, ProfilesSplashProxyFactory
 from .test_render import _BaseRenderTest
 
 class BlackWhiteProxyFactoryTest(unittest.TestCase):
@@ -18,10 +18,10 @@ class BlackWhiteProxyFactoryTest(unittest.TestCase):
             ]
         }
         params.update(kwargs)
-        return BlackWhiteQNetworkProxyFactory(**params)
+        return BlackWhiteSplashProxyFactory(**params)
 
     def test_noproxy(self):
-        f = BlackWhiteQNetworkProxyFactory()
+        f = BlackWhiteSplashProxyFactory()
         self.assertFalse(f.shouldUseProxyList('http', 'crawlera.com'))
 
     def test_whitelist(self):
@@ -75,13 +75,14 @@ class HtmlProxyRenderTest(_BaseRenderTest):
         r = self.request({'url': 'http://localhost:8998/jsrender',
                           'proxy': '../this-is-not-a-proxy-profile'})
         self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.text.strip(), SplashQNetworkProxyFactory.NO_PROXY_PROFILE_MSG)
+        self.assertEqual(r.text.strip(), ProfilesSplashProxyFactory.NO_PROXY_PROFILE_MSG)
+
 
     def test_nonexisting(self):
         r = self.request({'url': 'http://localhost:8998/jsrender',
                           'proxy': 'nonexisting'})
         self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.text.strip(), SplashQNetworkProxyFactory.NO_PROXY_PROFILE_MSG)
+        self.assertEqual(r.text.strip(), ProfilesSplashProxyFactory.NO_PROXY_PROFILE_MSG)
 
     def test_no_proxy_settings(self):
         r = self.request({'url': 'http://localhost:8998/jsrender',


### PR DESCRIPTION
It seems that after many false starts I finally came up with a solution for #39 :) 

The main stumbling block was per-request proxy profile support: QNetworkProxyFactory.createRequest effectively receives only an URL that is to be proxied (this is hardcoded in C++ code, see http://qt.gitorious.org/qt/qt/source/67376be28ca51930ff0f4fad2dd58f53968655a9:src/network/access/qnetworkaccessmanager.cpp#L718 ), but we need it to make a decision based on request to splash itself. So the question was how to pass information to QNetworkProxyFactory.createRequest.

What didn't work:
- simple hacks like setting cache to None - anyways, it is documented that multiple caches sharing the same folder are not supported by QT;
- subclassing QNetworkRequest to carry extra information, or just setting some attribute on request - custom request gets converted to standard request somewhere in C++ land;
- using QNetworkRequest.setAttribute - this worked only for the first, "main" request; requests created automatically (e.g. to images, css and js files) don't copy this attribute
- shared state for QNetworkAccessManager - it looks wrong.

What worked is to use QNetworkRequest.setOriginatingObject and access web_page attributes via this originatingObject - as always, it seems obvious in retrospect :) 

There are some consequences of a single QNetworkAccessManager, e.g. 6 connections per domain/port become a global limit.
