### PR TITLE
Fix for ReactorNotRunning exception

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ psutil
 pyOpenSSL
 requests >= 1.0
 Pillow
+
+# Probably you would like to install pdb4qt for debugging
+# https://pypi.python.org/pypi/pdb4qt/

--- a/splash/server.py
+++ b/splash/server.py
@@ -142,9 +142,11 @@ def monitor_maxrss(maxrss):
         maxrss = phymem_usage().total * maxrss / (1024 ** 2)
 
     def check_maxrss():
-        if resource.getrusage(resource.RUSAGE_SELF).ru_maxrss > maxrss * 1024:
+        resident_set_size = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if resident_set_size > maxrss * 1024 and reactor.running:
             log.msg("maxrss exceeded %d MB, shutting down..." % maxrss)
             reactor.stop()
+
     if maxrss:
         log.msg("maxrss limit: %d MB" % maxrss)
         t = task.LoopingCall(check_maxrss)


### PR DESCRIPTION
Found this one in logs:

```
2014-05-14 10:23:02+0000 [-] maxrss exceeded 1239 MB, shutting down...
2014-05-14 10:23:02+0000 [splash.proxy_server.SplashProxyFactory] (TCP Port 8051 Closed)
2014-05-14 10:23:02+0000 [splash.proxy_server.SplashProxyFactory] Stopping factory <splash.proxy_server.SplashProxyFactory instance at 0x219d638>
2014-05-14 10:23:02+0000 [twisted.manhole.telnet.ShellFactory] (TCP Port 5023 Closed)
2014-05-14 10:23:02+0000 [twisted.manhole.telnet.ShellFactory] Stopping factory <twisted.manhole.telnet.ShellFactory instance at 0x1b51c20>
2014-05-14 10:23:02+0000 [twisted.web.server.Site] (TCP Port 8050 Closed)
2014-05-14 10:23:02+0000 [twisted.web.server.Site] Stopping factory <twisted.web.server.Site instance at 0x2160c68>
2014-05-14 10:23:04+0000 [stats] {"maxrss": 1354556, "load": [0.22, 0.36, 0.44], "fds": 39, "qsize": 0, "rendertime": 5.2751548290252686, "active": 9, "path": "/render.json", "args": {"console": ["1"], "script": ["1"], "url": ["https://www.google.com/shopping/express/#HomePlace:cat=469.2915.473.477.2779&s=0&c=24&mall=Manhattan"], "html": ["1"], "js_source": ["\nvar oldTimeout = setTimeout;\nwindow.setTimeout = function(callback, timeout) {\n  return callback();\n};\n\nvar getProductUrl = function () {\n  var anchors = document.querySelectorAll('div > a');\n  for (var i=0; i<anchors.length; i++) {\n    if (anchors[i].href.indexOf(\"ProductDetailPlace\") !== -1) {\n      return anchors[i].href;\n    }\n  }\n};\n\nvar mouseoverProduct = function (productDiv) {\n  var event = document.createEvent('Event');\n  event.initEvent('mouseover', true, true);\n  productDiv.dispatchEvent(event);\n};\n\nvar visitProduct = function (productDiv) {\n  mouseoverProduct(productDiv);\n  var anchor = getProductUrl();\n  return anchor;\n};\n\nvar iterProductDivs = function () {\n  var urls = [];\n  var url;\n  var productDivs = document.querySelectorAll('div.contentArea ol > li > div');\n  for (var ipd=0; ipd<productDivs.length; ipd++) {\n    url = visitProduct(productDivs[ipd])\n    if (url) {\n      console.log(url);\n    }\n    urls.push(url);\n  }\n  return urls;\n};\n\niterProductDivs();\n"], "wait": ["5"]}, "_id": 35247528}
2014-05-14 10:23:05+0000 [stats] {"maxrss": 1354592, "load": [0.22, 0.36, 0.44], "fds": 39, "qsize": 0, "rendertime": 5.255741119384766, "active": 7, "path": "/render.json", "args": {"console": ["1"], "script": ["1"], "url": ["https://www.google.com/shopping/express/#HomePlace:cat=537.2764.538&s=0&c=24&mall=Manhattan"], "html": ["1"], "js_source": ["\nvar oldTimeout = setTimeout;\nwindow.setTimeout = function(callback, timeout) {\n  return callback();\n};\n\nvar getProductUrl = function () {\n  var anchors = document.querySelectorAll('div > a');\n  for (var i=0; i<anchors.length; i++) {\n    if (anchors[i].href.indexOf(\"ProductDetailPlace\") !== -1) {\n      return anchors[i].href;\n    }\n  }\n};\n\nvar mouseoverProduct = function (productDiv) {\n  var event = document.createEvent('Event');\n  event.initEvent('mouseover', true, true);\n  productDiv.dispatchEvent(event);\n};\n\nvar visitProduct = function (productDiv) {\n  mouseoverProduct(productDiv);\n  var anchor = getProductUrl();\n  return anchor;\n};\n\nvar iterProductDivs = function () {\n  var urls = [];\n  var url;\n  var productDivs = document.querySelectorAll('div.contentArea ol > li > div');\n  for (var ipd=0; ipd<productDivs.length; ipd++) {\n    url = visitProduct(productDivs[ipd])\n    if (url) {\n      console.log(url);\n    }\n    urls.push(url);\n  }\n  return urls;\n};\n\niterProductDivs();\n"], "wait": ["5"]}, "_id": 35278792}
2014-05-14 10:24:02+0000 [-] maxrss exceeded 1239 MB, shutting down...
2014-05-14 10:24:02+0000 [-] Unhandled error in Deferred:
2014-05-14 10:24:02+0000 [-] Unhandled Error
        Traceback (most recent call last):
          File "/usr/lib/python2.7/dist-packages/qt4reactor.py", line 266, in run
            self._blockApp.exec_()
          File "/usr/lib/python2.7/dist-packages/qt4reactor.py", line 231, in _iterate
            self.runUntilCurrent()
          File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 800, in runUntilCurrent
            call.func(*call.args, **call.kw)
          File "/usr/lib/python2.7/dist-packages/twisted/internet/task.py", line 208, in __call__
            d = defer.maybeDeferred(self.f, *self.a, **self.kw)
        --- <exception caught here> ---
          File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 134, in maybeDeferred
            result = f(*args, **kw)
          File "/usr/lib/pymodules/python2.7/splash/server.py", line 131, in check_maxrss
            reactor.stop()
          File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 577, in stop
            "Can't stop reactor that isn't running.")
        twisted.internet.error.ReactorNotRunning: Can't stop reactor that isn't running.

```

Looks like `reactor.stop()` was called twice which caused the error. Added `reactor.running` check to avoid this.
