### PR TITLE
[MRG] Downgrade base Docker image to 12.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:14.04
+FROM ubuntu:12.04
 ENV DEBIAN_FRONTEND noninteractive
 
 # software-properties-common contains "add-apt-repository" command for PPA conf
-RUN apt-get update && apt-get install -y software-properties-common
+RUN apt-get update && apt-get install -y software-properties-common python-software-properties
 
 # add a repo for libre2
 RUN add-apt-repository -y ppa:pi-rho/security
@@ -11,10 +11,12 @@ RUN sed 's/main$/main universe/' -i /etc/apt/sources.list && \
     apt-get update -q && \
     apt-get install -y netbase ca-certificates python \
         python-dev build-essential \
-        xvfb libqt4-webkit python-twisted python-qt4 libre2-dev \
-        git-core python-pip
+        xvfb libqt4-webkit python-qt4 libre2-dev \
+        git-core python-pip libicu48
 
+RUN pip install -U pip
 RUN pip install \
+            Twisted==14.0.2 \
             qt4reactor==1.6 \
             psutil==2.1.3 \
             adblockparser==0.3 \


### PR DESCRIPTION
Reported by @pawelmhm: the default Splash Docker container (scrapinghub/splash) exits after processing http://www.menards.com/main/home.html URL. I can reproduce it. With old Dockerfile (based on Ubuntu 12.04) there are no segfaults / exits. I tried to to downgrade the image to 12.04 (while keeping other stuff - no supervisord, etc); it helped.
