### PR TITLE
[WIP] Web view geometry inheritance revisited.

### DIFF
--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -14,6 +14,7 @@ from PyQt4.QtNetwork import QNetworkRequest
 from twisted.internet import defer
 from twisted.python import log
 from splash import defaults
+from splash.utils import parse_viewport
 from splash.qtutils import qurl2ascii, OPERATION_QT_CONSTANTS, qt2py, WrappedSignal
 from splash.har.utils import without_private
 
@@ -67,6 +68,8 @@ class BrowserTab(object):
         self._setup_webpage_events()
 
         self.web_view = QWebView()
+        geometry = render_options.get_geometry()
+        self.web_view.setGeometry(0, 0, *parse_viewport(geometry))
         self.web_view.setPage(self.web_page)
         self.web_view.setAttribute(Qt.WA_DeleteOnClose, True)
 

--- a/splash/render_options.py
+++ b/splash/render_options.py
@@ -170,6 +170,9 @@ class RenderOptions(object):
         except ValueError:
             raise BadOption("Invalid viewport format: %s" % viewport)
 
+    def get_geometry(self):
+        return self.get("geometry", self.get_viewport())
+
     def get_filters(self, pool=None, adblock_rules=None):
         filter_names = self.get('filters', '')
         filter_names = [f for f in filter_names.split(',') if f]

--- a/splash/tests/test_geometry.py
+++ b/splash/tests/test_geometry.py
@@ -1,0 +1,27 @@
+from .test_runjs import BaseJsTest
+
+
+class RunGeometryTest(BaseJsTest):
+    _clientwidth_js_code = '''
+        (function () {
+            return document.body.clientWidth;
+        })();
+    '''
+
+    def width_test(self, dimension, width):
+        params = {'viewport': 'full', 'wait': '10', 'geometry': dimension}
+        ret = self._runjs_request(self._clientwidth_js_code, params=params).json()
+        js_width = int(ret['script'])
+        assert width == js_width
+
+    def test_small(self):
+        return self.width_test('480x800', 480)
+
+    def test_tablet(self):
+        return self.width_test('768x1200', 768)
+
+    def test_desktop(self):
+        return self.width_test('1024x768', 1024)
+
+    def test_large_desktop(self):
+        return self.width_test('1280x1024', 1280)

--- a/splash/tests/test_runjs.py
+++ b/splash/tests/test_runjs.py
@@ -13,8 +13,19 @@ function getContents(){
 getContents();"""
 
 
-class RunJsTest(BaseRenderTest):
+class BaseJsTest(BaseRenderTest):
     endpoint = 'render.json'
+
+    def _runjs_request(self, js_source, endpoint=None, params=None, headers=None):
+        query = {'url': self.mockurl("jsrender"), 'script': 1}
+        query.update(params or {})
+        req_headers = {'content-type': 'application/javascript'}
+        req_headers.update(headers or {})
+        return self.post(query, endpoint=endpoint,
+                         payload=js_source, headers=req_headers)
+
+
+class RunJsTest(BaseRenderTest):
 
     def test_simple_js(self):
         js_source = "function test(x){ return x; } test('abc');"
@@ -88,14 +99,6 @@ test('Changed');"""
         r = self._runjs_request(js_source, params=params)
         self.assertStatusCode(r, 400)
 
-
-    def _runjs_request(self, js_source, endpoint=None, params=None, headers=None):
-        query = {'url': self.mockurl("jsrender"), 'script': 1}
-        query.update(params or {})
-        req_headers = {'content-type': 'application/javascript'}
-        req_headers.update(headers or {})
-        return self.post(query, endpoint=endpoint,
-                         payload=js_source, headers=req_headers)
 
 
 class RunJsCrossDomainTest(BaseRenderTest):

--- a/splash/utils.py
+++ b/splash/utils.py
@@ -9,6 +9,7 @@ import inspect
 import resource
 from collections import defaultdict
 import psutil
+from splash import defaults
 
 
 _REQUIRED = object()
@@ -79,3 +80,15 @@ def truncated(text, max_length=100, msg='...'):
         return text
     else:
         return text[:max_length] + msg
+
+
+def parse_viewport(size):
+    """
+    Takes size as in 'WidthXHeight' format and returns in (int, int) tuple.
+    """
+    return map(int, size.split('x'))
+
+
+def display_profile_to_dimension(profile):
+    p = profile.replace('-', '_').upper() + '_VIEWPORT'
+    return getattr(defaults, p, defaults.VIEWPORT)


### PR DESCRIPTION
I tried to bring the notion of different device screen option which allows you to render the page as though the webpage is visited from a particular screen sized device.

The motivation:
I've come across with a website which dynamically changes its content and hides some of information if the device is smaller than a desktop. QWebPage inherits screen geometry information from QWebView (which does the same from QWidget most probably). So far, the geometry run at default value (640x480 if i'm not wrong). This PR, make QWebPage to set geometry immediate after it is created, i didnt test the effect changing the geometry at runtime and what happens to QWebPage.

This PR brings a simple unit test which expects a screen width to be a default value. I added custom yield_fixtures, having thinking to run TestServer() with different settings object which should be carried down to the WebpageRender. Now, there is no way to write test which uses different settings/configuration unless defaults.py is physically changed on disk.

So, do you think, is there a need for small refactoring about about running server at different configuration or is it better to look for an update which allows you to change the geometry (device screen size) at runtime, based on a url parameter for example?