### PR TITLE
splash:runjs and splash:evaljs

### DIFF
--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -297,7 +297,7 @@ For example, the following innocent-looking code (using jQuery) may fail:
 
     splash:evaljs("$(console.log('foo'));")
 
-A gotcha is that to allow chaining jQuery $ returns a huge object,
+A gotcha is that to allow chaining jQuery ``$`` function returns a huge object,
 :ref:`splash-evaljs` tries to serialize it and convert to Lua. It is a waste
 of resources, and it could trigger internal protection measures;
 :ref:`splash-runjs` doesn't have this problem.

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -332,8 +332,8 @@ Set JavaScript to load automatically on each page load.
 
 :ref:`splash-autoload` allows to execute JavaScript code at each page load.
 :ref:`splash-autoload` doesn't doesn't execute the passed
-JavaScript code itself. To execute some code once, after page is loaded
-use :ref:`splash-evaljs` or :ref:`splash-jsfunc`.
+JavaScript code itself. To execute some code once, *after* page is loaded
+use :ref:`splash-runjs` or :ref:`splash-jsfunc`.
 
 :ref:`splash-autoload` can be used to preload utility JavaScript libraries
 or replace JavaScript objects before a webpage has a chance to do it.

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -272,7 +272,8 @@ last statement.
 * snippet - a string with JavaScript source code to execute.
 
 **Returns:** the result of the last statement in ``snippet``,
-converted from JavaScript to Lua data types.
+converted from JavaScript to Lua data types. In case of syntax errors or
+JavaScript exceptions an error is raised.
 
 JavaScript → Lua conversion rules are the same as for
 :ref:`splash:jsfunc <js-lua-conversion-rules>`.
@@ -286,9 +287,9 @@ Example:
 
     local title = splash:evaljs("document.title")
 
-:ref:`splash:jsfunc() <splash-jsfunc>` is more versatile because it allows to pass arguments
-to JavaScript functions; to do that with ``splash:evaljs`` string formatting
-must be used. Compare:
+:ref:`splash:jsfunc() <splash-jsfunc>` is more versatile because it allows
+to pass arguments to JavaScript functions; to do that with ``splash:evaljs``
+string formatting must be used. Compare:
 
 .. code-block:: lua
 

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -257,15 +257,15 @@ If a JavaScript function throws an error, it is re-throwed as a Lua error.
 To handle errors it is better to use JavaScript try/catch because some of the
 information about the error can be lost in JavaScript → Lua conversion.
 
-.. _splash-runjs:
+.. _splash-evaljs:
 
-splash:runjs
-------------
+splash:evaljs
+-------------
 
 Execute a JavaScript snippet in page context and return the result of the
 last statement.
 
-**Signature:** ``result = splash:runjs(snippet)``
+**Signature:** ``result = splash:evaljs(snippet)``
 
 **Parameters:**
 
@@ -277,17 +277,17 @@ converted from JavaScript to Lua data types.
 JavaScript → Lua conversion rules are the same as for
 :ref:`splash:jsfunc <js-lua-conversion-rules>`.
 
-``splash:runjs`` is useful to evaluate short snippets of code or to
+``splash:evaljs`` is useful to evaluate short snippets of code or to
 execute some code without defining a wrapper function.
 
 Example:
 
 .. code-block:: lua
 
-    local title = splash:runjs("document.title")
+    local title = splash:evaljs("document.title")
 
 :ref:`splash:jsfunc() <splash-jsfunc>` is more versatile because it allows to pass arguments
-to JavaScript functions; to do that with ``splash:runjs`` string formatting
+to JavaScript functions; to do that with ``splash:evaljs`` string formatting
 must be used. Compare:
 
 .. code-block:: lua
@@ -299,7 +299,7 @@ must be used. Compare:
             tonumber(x),
             tonumber(y)
         )
-        return splash:runjs(js)
+        return splash:evaljs(js)
     end
 
     -- a simpler version using splash:jsfunc
@@ -332,7 +332,7 @@ Set JavaScript to load automatically on each page load.
 :ref:`splash-autoload` allows to execute JavaScript code at each page load.
 :ref:`splash-autoload` doesn't doesn't execute the passed
 JavaScript code itself. To execute some code once, after page is loaded
-use :ref:`splash-runjs` or :ref:`splash-jsfunc`.
+use :ref:`splash-evaljs` or :ref:`splash-jsfunc`.
 
 :ref:`splash-autoload` can be used to preload utility JavaScript libraries
 or replace JavaScript objects before a webpage has a chance to do it.
@@ -348,7 +348,7 @@ Example:
             }
         ]])
         assert(splash:go(splash.args.url))
-        return splash:runjs("get_document_title()")
+        return splash:evaljs("get_document_title()")
     end
 
 For the convenience, when a first :ref:`splash-autoload` argument starts
@@ -360,7 +360,7 @@ Example 2 - make sure a remote library is available:
     function main(splash)
         assert(splash:autoload("https://code.jquery.com/jquery-2.1.3.min.js"))
         assert(splash:go(splash.args.url))
-        return splash:runjs("$.fn.jquery")  -- return jQuery version
+        return splash:evaljs("$.fn.jquery")  -- return jQuery version
     end
 
 To disable URL auto-detection use 'source' and 'url' arguments:

--- a/docs/scripting-tutorial.rst
+++ b/docs/scripting-tutorial.rst
@@ -48,7 +48,7 @@ Let's start with a basic example:
      function main(splash)
          splash:go("http://example.com")
          splash:wait(0.5)
-         local title = splash:runjs("document.title")
+         local title = splash:evaljs("document.title")
          return {title=title}
      end
 
@@ -116,7 +116,7 @@ Here is a part of the first example:
 
     splash:go("http://example.com")
     splash:wait(0.5)
-    local title = splash:runjs("document.title")
+    local title = splash:evaljs("document.title")
 
 The code looks like a standard procedural code; there are no callbacks
 or fancy control flow structures. It doesn't mean Splash works in a synchronous
@@ -175,7 +175,7 @@ A similar Splash script:
         if not ok then
             return "?"
         end
-        return splash:runjs([[
+        return splash:evaljs([[
             document.querySelector('div.profile td.stat.stat-last div.statnum').innerText;
         ]]);
     end
@@ -282,12 +282,12 @@ named arguments use curly braces: ``splash:foo{name1=val1, name2=val2}``:
     -- Examples of positional arguments:
     splash:go("http://example.com")
     splash:wait(0.5, false)
-    local title = splash:runjs("document.title")
+    local title = splash:evaljs("document.title")
 
     -- The same using keyword arguments:
     splash:go{url="http://example.com"}
     splash:wait{time=0.5, cancel_on_redirect=false}
-    local title = splash:runjs{source="document.title"}
+    local title = splash:evaljs{source="document.title"}
 
     -- Mixed arguments example:
     splash:wait{0.5, cancel_on_redirect=false}
@@ -480,7 +480,7 @@ Usage:
 
         -- wait until <h1> element is loaded
         utils.wait_for(splash, function()
-           return splash:runjs("document.querySelector('h1') != null")
+           return splash:evaljs("document.querySelector('h1') != null")
         end)
 
         return splash:html()
@@ -518,7 +518,7 @@ Usage:
 
         -- wait until <h1> element is loaded
         splash:wait_for(function()
-           return splash:runjs("document.querySelector('h1') != null")
+           return splash:evaljs("document.querySelector('h1') != null")
         end)
 
         return splash:html()

--- a/docs/scripting-tutorial.rst
+++ b/docs/scripting-tutorial.rst
@@ -201,7 +201,7 @@ Observations:
 * in Splash variant ``followers`` function can return a result
   (a number of twitter followers); also, it doesn't need a "callback" argument;
 * instead of a ``page.open`` callback which receives "status" argument
-  there is a "blocking" ``splash:go`` call which returns "ok" flag;
+  there is a "blocking" :ref:`splash-go` call which returns "ok" flag;
 * error handling is different: in case of an HTTP 4xx or 5xx error
   PhantomJS doesn't return an error code to ``page.open`` callback - example
   script will try to get the followers nevertheless because "status" won't
@@ -236,6 +236,14 @@ handling?). Splash scripts are standard Lua code.
 Living Without Callbacks
 ------------------------
 
+.. note::
+
+    For the curious, Splash uses Lua coroutines under the hood.
+
+    Internally, "main" function is executed as a coroutine by Splash,
+    and some of the ``splash:foo()`` methods use ``coroutine.yield``.
+    See http://www.lua.org/pil/9.html for Lua coroutines tutorial.
+
 In Splash scripts it is not explicit which calls are async and which calls
 are blocking. It is a common criticism of coroutines/greenlets; check e.g.
 `this <https://glyph.twistedmatrix.com/2014/02/unyielding.html>`__ article
@@ -255,15 +263,6 @@ Currently async methods are :ref:`splash-go`, :ref:`splash-wait`,
 :ref:`splash-autoload` becomes async when an URL is passed.
 Most splash methods are currently **not** async, but thinking
 of them as of async will allow your scripts to work if we ever change that.
-
-.. note::
-
-    For the curious, Splash uses Lua coroutines under the hood.
-
-    Internally, "main" function is executed as a coroutine by Splash,
-    and some of the ``splash:foo()`` methods use ``coroutine.yield``.
-    See http://www.lua.org/pil/9.html for Lua coroutines tutorial.
-
 
 Calling Splash Methods
 ----------------------

--- a/examples/phantomjs-follow.lua
+++ b/examples/phantomjs-follow.lua
@@ -17,7 +17,7 @@ function follow(splash, user)
   if not ok then
     return "Can't get followers of " .. user .. ': ' .. msg
   end
-  return splash:runjs([[
+  return splash:evaljs([[
     document.querySelector('div.profile td.stat.stat-last div.statnum').innerText;
   ]]);
 end

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -423,7 +423,7 @@ class BrowserTab(QObject):
         """
         with open(filename, 'rb') as f:
             script = f.read().decode('utf-8')
-            return self.runjs(script)
+            return self.evaljs(script)
 
     def run_js_files(self, folder):
         """
@@ -454,11 +454,8 @@ class BrowserTab(QObject):
             follow_redirects=follow_redirects
         )
 
-    def runjs(self, js_source):
-        """
-        Run JS code in page context and return the result.
-        Only string results are supported.
-        """
+    def evaljs(self, js_source):
+        """ Run JS code in page context and return the result"""
         frame = self.web_page.mainFrame()
         res = frame.evaluateJavaScript(js_source)
         return qt2py(res)

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -51,6 +51,19 @@ end
 
 
 --
+-- This decorator expects function return value to be a Python list
+-- and unpacks it to Lua multiple return values.
+--
+local function unpacks_multiple_return_values(func)
+  return function(...)
+    -- Max allowed list size is 10; it is more than enough for
+    -- functions which return multiple values. This trick is needed
+    -- to handle `nil` as a first value correctly.
+    return table.unpack(func(...), 1, 10)
+  end
+end
+
+--
 -- Lua wrapper for Splash Python object.
 --
 -- It hides attributes that should not be exposed,
@@ -74,6 +87,10 @@ function Splash.create(py_splash)
 
     if opts.is_async then
       command = yields_result(command)
+    end
+
+    if opts.multiple_return_values then
+      command = unpacks_multiple_return_values(command)
     end
 
     self[key] = command

--- a/splash/qtrender.py
+++ b/splash/qtrender.py
@@ -152,7 +152,7 @@ class DefaultRenderScript(RenderScript):
                 # XXX: shouldn't we keep injecting scripts after redirects?
                 self.tab.run_js_files(js_profile)
 
-            js_output = self.tab.runjs(js_source)  #.encode('utf8')
+            js_output = self.tab.evaljs(js_source)
             if self.console:
                 js_console_output = self.tab._jsconsole_messages()
 

--- a/splash/qtrender.py
+++ b/splash/qtrender.py
@@ -150,9 +150,9 @@ class DefaultRenderScript(RenderScript):
 
             if js_profile:
                 # XXX: shouldn't we keep injecting scripts after redirects?
-                self.tab.run_js_files(js_profile)
+                self.tab.run_js_files(js_profile, handle_errors=False)
 
-            js_output = self.tab.evaljs(js_source)
+            js_output = self.tab.evaljs(js_source, handle_errors=False)
             if self.console:
                 js_console_output = self.tab._jsconsole_messages()
 

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -167,7 +167,7 @@ class _WrappedJavascriptFunction(object):
         """ % {"func_text": func_text, "args": args_text}
 
         # print(wrapper_script)
-        res = self.tab.runjs(wrapper_script)
+        res = self.tab.evaljs(wrapper_script)
 
         if not isinstance(res, dict):
             raise ScriptError("[lua] unknown error during JS function call: %r; %r" % (res, wrapper_script))
@@ -298,8 +298,8 @@ class Splash(object):
         self.tab.stop_loading()
 
     @command()
-    def runjs(self, snippet):
-        res = self.tab.runjs(snippet)
+    def evaljs(self, snippet):
+        res = self.tab.evaljs(snippet)
         return res
 
     @command()

--- a/splash/tests/lua_modules/utils.lua
+++ b/splash/tests/lua_modules/utils.lua
@@ -1,7 +1,7 @@
 local utils = {}
 
 function utils.get_document_title(splash)
-  return splash:runjs("document.title")
+  return splash:evaljs("document.title")
 end
 
 local secret = require("secret")

--- a/splash/tests/lua_modules/utils_patch.lua
+++ b/splash/tests/lua_modules/utils_patch.lua
@@ -1,5 +1,5 @@
 local Splash = require("splash")
 
 function Splash:get_document_title()
-  return self:runjs("document.title")
+  return self:evaljs("document.title")
 end

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -641,7 +641,7 @@ class JsfuncTest(BaseLuaRenderTest):
         end
         """)
         self.assertNotIn("str()", resp.text)
-        self.assertIn("AttributeError", resp.text)
+        self.assertIn("error reading Python attribute/item", resp.text)
 
 
 class WaitTest(BaseLuaRenderTest):

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -328,12 +328,12 @@ class ErrorsTest(BaseLuaRenderTest):
 
 
 
-class RunjsTest(BaseLuaRenderTest):
+class EvaljsTest(BaseLuaRenderTest):
 
-    def assertRunjsResult(self, js, result, type):
+    def assertEvaljsResult(self, js, result, type):
         resp = self.request_lua("""
         function main(splash)
-            local res = splash:runjs([[%s]])
+            local res = splash:evaljs([[%s]])
             return {res=res, tp=type(res)}
         end
         """ % js)
@@ -344,54 +344,54 @@ class RunjsTest(BaseLuaRenderTest):
             self.assertEqual(resp.json(), {'res': result, 'tp': type})
 
     def test_numbers(self):
-        self.assertRunjsResult("1.0", 1.0, "number")
-        self.assertRunjsResult("1", 1, "number")
-        self.assertRunjsResult("1+2", 3, "number")
+        self.assertEvaljsResult("1.0", 1.0, "number")
+        self.assertEvaljsResult("1", 1, "number")
+        self.assertEvaljsResult("1+2", 3, "number")
 
     def test_inf(self):
-        self.assertRunjsResult("1/0", float('inf'), "number")
-        self.assertRunjsResult("-1/0", float('-inf'), "number")
+        self.assertEvaljsResult("1/0", float('inf'), "number")
+        self.assertEvaljsResult("-1/0", float('-inf'), "number")
 
     def test_string(self):
-        self.assertRunjsResult("'foo'", u'foo', 'string')
+        self.assertEvaljsResult("'foo'", u'foo', 'string')
 
     def test_bool(self):
-        self.assertRunjsResult("true", True, 'boolean')
+        self.assertEvaljsResult("true", True, 'boolean')
 
     def test_undefined(self):
-        self.assertRunjsResult("undefined", None, 'nil')
+        self.assertEvaljsResult("undefined", None, 'nil')
 
     def test_null(self):
         # XXX: null is converted to an empty string by QT,
         # we can't distinguish it from a "real" empty string.
-        self.assertRunjsResult("null", "", 'string')
+        self.assertEvaljsResult("null", "", 'string')
 
     def test_unicode_string(self):
-        self.assertRunjsResult("'привет'", u'привет', 'string')
+        self.assertEvaljsResult("'привет'", u'привет', 'string')
 
     def test_unicode_string_in_object(self):
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             'var o={}; o["ключ"] = "значение"; o',
             {u'ключ': u'значение'},
             'table'
         )
 
     def test_nested_object(self):
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             'var o={}; o["x"] = {}; o["x"]["y"] = 5; o["z"] = "foo"; o',
             {"x": {"y": 5}, "z": "foo"},
             'table'
         )
 
     def test_array(self):
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             'x = [3, 2, 1, "foo", ["foo", [], "bar"], {}]; x',
             [3, 2, 1, "foo", ["foo", [], "bar"], {}],
             'table',
         )
 
     def test_self_referencing(self):
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             'var o={}; o["x"] = "5"; o["y"] = o; o',
             {"x": "5"},  # self reference is discarded
             'table'
@@ -399,13 +399,13 @@ class RunjsTest(BaseLuaRenderTest):
 
     def test_function(self):
         # XXX: functions are not returned by QT
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             "x = function(){return 5}; x",
             {},
             "table"
         )
 
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             "function(){return 5}",
             None,
             "nil"
@@ -413,14 +413,14 @@ class RunjsTest(BaseLuaRenderTest):
 
     def test_object_with_function(self):
         # XXX: complex objects are unsupported
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             '{"x":2, "y": function(){}}',
             None,
             "nil",
         )
 
     def test_function_call(self):
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             "function x(){return 5}; x();",
             5,
             "number"
@@ -430,14 +430,14 @@ class RunjsTest(BaseLuaRenderTest):
         # XXX: Date objects are converted to ISO8061 strings.
         # Does it make sense to do anything else with them?
         # E.g. make them available to Lua as tables?
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             'x = new Date("21 May 1958 10:12 UTC"); x',
             "1958-05-21T10:12:00Z",
             "string"
         )
 
     def test_regexp(self):
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             '/my-regexp/i',
             {
                 u'_jstype': u'RegExp',
@@ -447,7 +447,7 @@ class RunjsTest(BaseLuaRenderTest):
             'table'
         )
 
-        self.assertRunjsResult(
+        self.assertEvaljsResult(
             '/my-regexp/',
             {
                 u'_jstype': u'RegExp',
@@ -1473,13 +1473,13 @@ class AutoloadTest(BaseLuaRenderTest):
             assert(splash:autoload("window.FOO = 'bar'"))
 
             splash:go(splash.args.url)
-            local foo1 = splash:runjs("FOO")
+            local foo1 = splash:evaljs("FOO")
 
-            splash:runjs("window.FOO = 'spam'")
-            local foo2 = splash:runjs("FOO")
+            splash:evaljs("window.FOO = 'spam'")
+            local foo2 = splash:evaljs("FOO")
 
             splash:go(splash.args.url)
-            local foo3 = splash:runjs("FOO")
+            local foo3 = splash:evaljs("FOO")
             return {foo1=foo1, foo2=foo2, foo3=foo3}
         end
         """, {"url": self.mockurl("getrequest")})


### PR DESCRIPTION
This should fix https://github.com/scrapinghub/splash/issues/149. 

It is backwards-incompatible: 

1. Old `splash:runjs` is renamed to `splash:evaljs` and got an ability to raise JavaScript errors. 
2. New `splash:runjs` doesn't build and return the result; instead it reports JavaScript errors in a return value.