### PR TITLE
Split viewport size and full-page rendering parameters

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -90,20 +90,29 @@ allowed_domains : string : optional
 .. _arg-viewport:
 
 viewport : string : optional
-  View width and height (in pixels) of the browser viewport
-  to render the web page. Format is "<width>x<heigth>", e.g. 800x600.
-  It also accepts 'full' as value; viewport=full means that the whole
-  page (possibly very tall) will be rendered. Default value is 1024x768.
 
-  'viewport' parameter is more important for PNG rendering;
-  it is supported for all rendering endpoints because javascript
-  code execution can depend on viewport size.
+  View width and height (in pixels) of the browser viewport to render the web
+  page. Format is "<width>x<height>", e.g. 800x600.  Default value is 1366x768.
+
+  'viewport' parameter is more important for PNG rendering; it is supported for
+  all rendering endpoints because javascript code execution can depend on
+  viewport size.
+
+  For backward compatibility reasons, it also accepts 'full' as value;
+  ``viewport=full`` is semantically equivalent to ``render_all=1`` (see
+  :ref:`arg-render-all`).
+
+.. _arg-render-all:
+
+render_all : int : optional
+  Render the whole webpage (possibly very tall) when ``1``, possible values are
+  ``1`` and ``0``.  Default is ``0``.
 
 .. note::
 
-    viewport=full requires non-zero 'wait' parameter. This is
-    an unfortunate restriction, but it seems that this is the only
-    way to make rendering work reliably with viewport=full.
+    ``render_all=1`` requires non-zero :ref:`arg-wait` parameter. This is an
+    unfortunate restriction, but it seems that this is the only way to make
+    rendering work reliably with ``render_all=1``.
 
 .. _arg-images:
 
@@ -735,6 +744,9 @@ X-Splash-width : string
 
 X-Splash-height : string
   Same as :ref:`'height' <arg-height>` argument for `render.png`_.
+
+X-Splash-render-all : string
+  Same as :ref:`'render_all' <arg-render-all>` argument for `render.png`_.
 
 X-Splash-html : string
   Same as :ref:`'html' <arg-html>` argument for `render.json`_.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -105,8 +105,9 @@ viewport : string : optional
 .. _arg-render-all:
 
 render_all : int : optional
-  Extend the viewport to include the whole webpage (possibly very tall) when
-  ``1`` before rendering.  Possible values are ``1`` and ``0``.  Default is ``0``.
+  Possible values are ``1`` and ``0``.  When ``render_all=1``, extend the
+  viewport to include the whole webpage (possibly very tall) before rendering.
+  Default is ``render_all=0``.
 
 .. note::
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -56,8 +56,8 @@ wait : float : optional
   (defaults to 0). Increase this value if you expect pages to contain
   setInterval/setTimeout javascript calls, because with wait=0
   callbacks of setInterval/setTimeout won't be executed. Non-zero
-  'wait' is also required for PNG rendering when viewport=full
-  (see later).
+  :ref:`wait <arg-wait>` is also required for PNG rendering when doing
+  full-page rendering (see :ref:`render_all <arg-render-all>`).
 
 .. _arg-proxy:
 
@@ -100,17 +100,17 @@ viewport : string : optional
 
   For backward compatibility reasons, it also accepts 'full' as value;
   ``viewport=full`` is semantically equivalent to ``render_all=1`` (see
-  :ref:`arg-render-all`).
+  :ref:`render_all <arg-render-all>`).
 
 .. _arg-render-all:
 
 render_all : int : optional
-  Render the whole webpage (possibly very tall) when ``1``, possible values are
-  ``1`` and ``0``.  Default is ``0``.
+  Extend the viewport to include the whole webpage (possibly very tall) when
+  ``1`` before rendering.  Possible values are ``1`` and ``0``.  Default is ``0``.
 
 .. note::
 
-    ``render_all=1`` requires non-zero :ref:`arg-wait` parameter. This is an
+    ``render_all=1`` requires non-zero :ref:`wait <arg-wait>` parameter. This is an
     unfortunate restriction, but it seems that this is the only way to make
     rendering work reliably with ``render_all=1``.
 

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -959,7 +959,7 @@ Set the browser viewport size.
 * height - integer, requested viewport height in pixels.
 
 This will change the size of the visible area and subsequent rendering
-commands, e.g. :ref:`splash-png`, will produce an image with the specified
+commands, e.g., :ref:`splash-png`, will produce an image with the specified
 size.
 
 :ref:`splash-png` uses the viewport size.

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -610,10 +610,10 @@ not a size of an area screenshot is taken of. For example, if the viewport
 is 1024px wide then ``splash:png{width=100}`` will return a screenshot
 of the whole viewport, but an image will be downscaled to 100px width.
 
-To set the viewport size use :ref:`splash-set-viewport` method or use
-*render_all* argument.  *render_all=true* is equivalent to running
-``splash:set_viewport('full')`` just before the rendering and restoring the
-viewport size afterwards.
+To set the viewport size use :ref:`splash-set-viewport-size`,
+:ref:`splash-set-viewport-full` or *render_all* argument.  *render_all=true* is
+equivalent to running ``splash:set_viewport_full()`` just before the rendering
+and restoring the viewport size afterwards.
 
 If the result of ``splash:png()`` is returned directly as a result of
 "main" function, the screenshot is returned as binary data:
@@ -932,37 +932,71 @@ Example:
          return {png=splash:png()}
      end
 
+.. _splash-get-viewport-size:
 
-.. _splash-set-viewport:
+splash:get_viewport_size
+------------------------
 
-splash:set_viewport
--------------------
+Get the browser viewport size.
 
-Set the browser viewport.
+**Signature:** ``width, height = splash:get_viewport_size()``
 
-**Signature:** ``width, height = splash:set_viewport(size)``
+**Returns:** two numbers: width and height of the viewport in pixels.
+
+
+.. _splash-set-viewport-size:
+
+splash:set_viewport_size
+------------------------
+
+Set the browser viewport size.
+
+**Signature:** ``splash:set_viewport_size(width, height)``
 
 **Parameters:**
 
-* size - string, width and height of the viewport.
-  Format is ``"<width>x<heigth>"``, e.g. ``"800x600"``.
-  It also accepts ``"full"`` as a value; ``"full"`` means that the viewport size
-  will be auto-detected to fit the whole page (possibly very tall).
-
-**Returns:** two numbers: width and height the viewport is set to, in pixels.
+* width - integer, requested viewport width in pixels;
+* height - integer, requested viewport height in pixels.
 
 This will change the size of the visible area and subsequent rendering
 commands, e.g. :ref:`splash-png`, will produce an image with the specified
 size.
 
-This will also affect ``window.innerWidth`` and ``window.innerHeight`` JS
-variables, but not immediately.  To see the new values in JS runtime and to
-ensure ``window.onresize`` callback has fired, use :ref:`splash-wait`.
+:ref:`splash-png` uses the viewport size.
 
-``splash:set_viewport("full")`` should be called only after page
-is loaded, and some time passed after that (use :ref:`splash-wait`). This is
-an unfortunate restriction, but it seems that this is the only
-way to make rendering work reliably with size="full".
+Example:
+
+.. code-block:: lua
+
+     function main(splash)
+         assert(splash:go("http://example.com"))
+         splash:set_viewport_size(1980, 1020)
+         return {png=splash:png()}
+     end
+
+.. note::
+
+   This will affect ``window.innerWidth`` and ``window.innerHeight`` JS
+   variables and invoke ``window.onresize`` event callback.  However this will
+   only happen during the next asynchronous operation and :ref:`splash-png` is
+   notably synchronous, so if you have resized a page and want it to react
+   accordingly before taking the screenshot, use :ref:`splash-wait`.
+
+.. _splash-set-viewport-full:
+
+splash:set_viewport_full
+------------------------
+
+Resize browser viewport to fit the whole page.
+
+**Signature:** ``width, height = splash:set_viewport_full()``
+
+**Returns:** two numbers: width and height the viewport is set to, in pixels.
+
+``splash:set_viewport_full`` should be called only after page is loaded, and
+some time passed after that (use :ref:`splash-wait`). This is an unfortunate
+restriction, but it seems that this is the only way to make automatic resizing
+work reliably.
 
 :ref:`splash-png` uses the viewport size.
 
@@ -973,7 +1007,7 @@ Example:
      function main(splash)
          assert(splash:go("http://example.com"))
          assert(splash:wait(0.5))
-         splash:set_viewport("full")
+         splash:set_viewport_full()
          return {png=splash:png()}
      end
 

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -593,12 +593,13 @@ splash:png
 
 Return a `width x height` screenshot of a current page in PNG format.
 
-**Signature:** ``png = splash:png{width=nil, height=nil}``
+**Signature:** ``png = splash:png{width=nil, height=nil, render_all=false}``
 
 **Parameters:**
 
 * width - optional, width of a screenshot in pixels;
-* height - optional, height of a screenshot in pixels.
+* height - optional, height of a screenshot in pixels;
+* render_all - optional, if ``true`` render the whole webpage.
 
 **Returns:** PNG screenshot data.
 
@@ -609,7 +610,10 @@ not a size of an area screenshot is taken of. For example, if the viewport
 is 1024px wide then ``splash:png{width=100}`` will return a screenshot
 of the whole viewport, but an image will be downscaled to 100px width.
 
-To set the viewport size use :ref:`splash-set-viewport` method.
+To set the viewport size use :ref:`splash-set-viewport` method or use
+*render_all* argument.  *render_all=true* is equivalent to running
+``splash:set_viewport('full')`` just before the rendering and restoring the
+viewport size afterwards.
 
 If the result of ``splash:png()`` is returned directly as a result of
 "main" function, the screenshot is returned as binary data:
@@ -946,6 +950,14 @@ Set the browser viewport.
   will be auto-detected to fit the whole page (possibly very tall).
 
 **Returns:** two numbers: width and height the viewport is set to, in pixels.
+
+This will change the size of the visible area and subsequent rendering
+commands, e.g. :ref:`splash-png`, will produce an image with the specified
+size.
+
+This will also affect ``window.innerWidth`` and ``window.innerHeight`` JS
+variables, but not immediately.  To see the new values in JS runtime and to
+ensure ``window.onresize`` callback has fired, use :ref:`splash-wait`.
 
 ``splash:set_viewport("full")`` should be called only after page
 is loaded, and some time passed after that (use :ref:`splash-wait`). This is

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -87,9 +87,7 @@ class BrowserTab(QObject):
         self.web_view.setPage(self.web_page)
         self.web_view.setAttribute(Qt.WA_DeleteOnClose, True)
 
-        self.set_window_size(render_options.get_window_size())
-        if render_options.get_viewport() != 'full':
-            self.set_viewport(render_options.get_viewport())
+        self.set_window_size(defaults.WINDOW_SIZE)
 
     def _set_default_webpage_options(self, web_page):
         """

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -739,8 +739,9 @@ class _BrowserTabLogger(object):
     def on_frame_load_started(self):
         self.log("mainFrame().loadStarted")
 
-    def on_contents_size_changed(self):
-        self.log("mainFrame().contentsSizeChanged")
+    @pyqtSlot('QSize')
+    def on_contents_size_changed(self, sz):
+        self.log("mainFrame().contentsSizeChanged: %s" % sz)
 
     def on_javascript_window_object_cleared(self):
         self.log("mainFrame().javaScriptWindowObjectCleared")

--- a/splash/defaults.py
+++ b/splash/defaults.py
@@ -8,7 +8,7 @@ MAX_WAIT_TIME = 10.0
 
 # Default size of browser window.  As there're no decorations, this affects
 # both "window.inner*" and "window.outer*" values.
-WINDOW_SIZE = '1024x768'
+WINDOW_SIZE = '1366x768'
 
 # Window size limitations.
 WINDOW_MAX_WIDTH = 20000

--- a/splash/defaults.py
+++ b/splash/defaults.py
@@ -6,12 +6,14 @@ WAIT_TIME = 0.0
 MAX_TIMEOUT = 60.0
 MAX_WAIT_TIME = 10.0
 
-# png rendering options
-VIEWPORT = '1024x768'
-VIEWPORT_FALLBACK = VIEWPORT  # do not set it to 'full'
-VIEWPORT_MAX_WIDTH = 20000
-VIEWPORT_MAX_HEIGTH = 20000
-VIEWPORT_MAX_AREA = 4000*4000
+# Default size of browser window.  As there're no decorations, this affects
+# both "window.inner*" and "window.outer*" values.
+WINDOW_SIZE = '1024x768'
+
+# Window size limitations.
+WINDOW_MAX_WIDTH = 20000
+WINDOW_MAX_HEIGTH = 20000
+WINDOW_MAX_AREA = 4000*4000
 
 MAX_WIDTH = 1920
 MAX_HEIGTH = 1080

--- a/splash/defaults.py
+++ b/splash/defaults.py
@@ -8,12 +8,12 @@ MAX_WAIT_TIME = 10.0
 
 # Default size of browser window.  As there're no decorations, this affects
 # both "window.inner*" and "window.outer*" values.
-WINDOW_SIZE = '1366x768'
+VIEWPORT_SIZE = '1366x768'
 
 # Window size limitations.
-WINDOW_MAX_WIDTH = 20000
-WINDOW_MAX_HEIGTH = 20000
-WINDOW_MAX_AREA = 4000*4000
+VIEWPORT_MAX_WIDTH = 20000
+VIEWPORT_MAX_HEIGTH = 20000
+VIEWPORT_MAX_AREA = 4000*4000
 
 MAX_WIDTH = 1920
 MAX_HEIGTH = 1080

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -59,7 +59,7 @@ local function unpacks_multiple_return_values(func)
     -- Max allowed list size is 10; it is more than enough for
     -- functions which return multiple values. This trick is needed
     -- to handle `nil` as a first value correctly.
-    return table.unpack(func(...), 1, 10)
+    return table.unpack(func(...), 1, 2)
   end
 end
 

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -56,9 +56,14 @@ end
 --
 local function unpacks_multiple_return_values(func)
   return function(...)
-    -- Max allowed list size is 10; it is more than enough for
-    -- functions which return multiple values. This trick is needed
-    -- to handle `nil` as a first value correctly.
+    -- Max allowed list size is 2; it is enough for functions which return
+    -- error flag along with a value. This trick is needed to handle `nil` as a
+    -- first value correctly.
+    --
+    -- Max size used to be 10, but it created full 10-element tuples which,
+    -- when passed through lupa, causing errors in Python runtime, because
+    -- Python callables, unlike Lua ones, are strict about the number of
+    -- arguments.
     return table.unpack(func(...), 1, 2)
   end
 end

--- a/splash/proxy_server.py
+++ b/splash/proxy_server.py
@@ -22,7 +22,8 @@ SPLASH_RESOURCES = {
 
 # Note the http header use '-' instead of '_' for the parameter names
 HTML_PARAMS = ['baseurl', 'timeout', 'wait', 'proxy', 'allowed-domains',
-               'viewport', 'js', 'js-source', 'images', 'filters']
+               'viewport', 'js', 'js-source', 'images', 'filters',
+               'window-size']
 PNG_PARAMS = ['width', 'height']
 JSON_PARAMS = ['html', 'png', 'iframes', 'script', 'console', 'history', 'har']
 

--- a/splash/proxy_server.py
+++ b/splash/proxy_server.py
@@ -23,7 +23,7 @@ SPLASH_RESOURCES = {
 # Note the http header use '-' instead of '_' for the parameter names
 HTML_PARAMS = ['baseurl', 'timeout', 'wait', 'proxy', 'allowed-domains',
                'viewport', 'js', 'js-source', 'images', 'filters',
-               'window-size']
+               'render-all']
 PNG_PARAMS = ['width', 'height']
 JSON_PARAMS = ['html', 'png', 'iframes', 'script', 'console', 'history', 'har']
 

--- a/splash/qtrender.py
+++ b/splash/qtrender.py
@@ -79,19 +79,20 @@ class DefaultRenderScript(RenderScript):
     """
     def start(self, url, baseurl=None, wait=None, viewport=None,
               js_source=None, js_profile=None, images=None, console=False,
-              headers=None, http_method='GET', body=None, window_size=None):
+              headers=None, http_method='GET', body=None,
+              render_all=False):
+
         self.url = url
         self.wait_time = defaults.WAIT_TIME if wait is None else wait
         self.js_source = js_source
         self.js_profile = js_profile
         self.console = console
-        self.viewport = defaults.WINDOW_SIZE if viewport is None else viewport
-        self.window_size = defaults.WINDOW_SIZE if window_size is None else window_size
+        self.viewport = defaults.VIEWPORT_SIZE if viewport is None else viewport
+        self.render_all = render_all or viewport == 'full'
 
         if images is not None:
             self.tab.set_images_enabled(images)
 
-        self.tab.set_window_size(self.window_size)
         if self.viewport != 'full':
             self.tab.set_viewport(self.viewport)
 
@@ -179,7 +180,8 @@ class PngRender(DefaultRenderScript):
         return super(PngRender, self).start(**kwargs)
 
     def get_result(self):
-        return self.tab.png(self.width, self.height)
+        return self.tab.png(self.width, self.height,
+                            render_all=self.render_all)
 
 
 class JsonRender(DefaultRenderScript):
@@ -198,7 +200,8 @@ class JsonRender(DefaultRenderScript):
         res = {}
 
         if self.include['png']:
-            res['png'] = self.tab.png(self.width, self.height, b64=True)
+            res['png'] = self.tab.png(self.width, self.height, b64=True,
+                                      render_all=self.render_all)
 
         if self.include['script'] and self.js_output:
             res['script'] = self.js_output

--- a/splash/qtrender.py
+++ b/splash/qtrender.py
@@ -78,19 +78,24 @@ class DefaultRenderScript(RenderScript):
     Subclasses choose how to return the result (as html, json, png).
     """
     def start(self, url, baseurl=None, wait=None, viewport=None,
-                  js_source=None, js_profile=None, images=None, console=False,
-                  headers=None, http_method='GET', body=None):
-
+              js_source=None, js_profile=None, images=None, console=False,
+              headers=None, http_method='GET', body=None, window_size=None):
         self.url = url
         self.wait_time = defaults.WAIT_TIME if wait is None else wait
         self.js_source = js_source
         self.js_profile = js_profile
         self.console = console
-        self.viewport = defaults.VIEWPORT if viewport is None else viewport
+        self.viewport = defaults.WINDOW_SIZE if viewport is None else viewport
+        self.window_size = defaults.WINDOW_SIZE if window_size is None else window_size
 
         if images is not None:
             self.tab.set_images_enabled(images)
 
+        # XXX: window/viewport size initialization is duplicated in
+        # BrowserTab._init_webpage.  If self.render_options specifies the same
+        # values as passed into this function, this section can be dropped.
+        # Now, are they always the same?
+        self.tab.set_window_size(self.window_size)
         if self.viewport != 'full':
             self.tab.set_viewport(self.viewport)
 

--- a/splash/qtrender.py
+++ b/splash/qtrender.py
@@ -91,10 +91,6 @@ class DefaultRenderScript(RenderScript):
         if images is not None:
             self.tab.set_images_enabled(images)
 
-        # XXX: window/viewport size initialization is duplicated in
-        # BrowserTab._init_webpage.  If self.render_options specifies the same
-        # values as passed into this function, this section can be dropped.
-        # Now, are they always the same?
         self.tab.set_window_size(self.window_size)
         if self.viewport != 'full':
             self.tab.set_viewport(self.viewport)

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -453,33 +453,22 @@ class Splash(object):
         sz = self.tab.web_page.viewportSize()
         return {'width': sz.width(), 'height': sz.height()}
 
-    @command(table_argument=True)
-    def set_viewport(self, size):
-        size = self.lua2python(size)
-        if size is None:
-            # This is to simplify handling of window_size query argument: if it
-            # is not specified its value in Lua is `nil`.
-            return
-        elif isinstance(size, dict):
-            size = '%dx%d' % (size['width'], size['height'])
-        return self.tab.set_viewport(size, raise_if_empty=True)
+    @command()
+    def set_viewport_size(self, width, height):
+        return self.tab.set_viewport('%dx%d' % (width, height))
+
+    @command()
+    def set_viewport_full(self):
+        return self.tab.set_viewport('full', raise_if_empty=True)
 
     @command()
     def get_window_size(self):
         sz = self.tab.web_view.size()
         return {'width': sz.width(), 'height': sz.height()}
 
-    @command(table_argument=True)
-    def set_window_size(self, size):
-        size = self.lua2python(size)
-        self.tab.logger.log("lua window size: %s" % size)
-        if size is None:
-            # This is to simplify handling of window_size query argument: if it
-            # is not specified its value in Lua is `nil`.
-            return
-        elif isinstance(size, dict):
-            size = '%dx%d' % (size['width'], size['height'])
-        self.tab.set_window_size(size)
+    @command()
+    def set_window_size(self, width, height):
+        self.tab.set_window_size('%dx%d' % (width, height))
 
     @command()
     def set_images_enabled(self, enabled):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -457,9 +457,9 @@ class Splash(object):
     def set_viewport_size(self, width, height):
         self.tab.set_viewport('%dx%d' % (width, height))
 
-    @command()
+    @command(multiple_return_values=True)
     def set_viewport_full(self):
-        self.tab.set_viewport('full')
+        return list(self.tab.set_viewport('full'))
 
     @command()
     def set_images_enabled(self, enabled):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -452,7 +452,21 @@ class Splash(object):
     def set_viewport(self, size):
         if size is None:
             return
-        return self.tab.set_viewport(size)
+        return self.tab.set_viewport(size, raise_if_empty=True)
+
+    @command()
+    def get_viewport_size(self):
+        sz = self.tab.web_page.viewportSize()
+        return sz.width(), sz.height()
+
+    @command()
+    def get_window_size(self):
+        sz = self.tab.web_view.size()
+        return sz.width(), sz.height()
+
+    @command()
+    def set_window_size(self, sz):
+        self.tab.set_window_size(sz)
 
     @command()
     def set_images_enabled(self, enabled):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -449,24 +449,37 @@ class Splash(object):
         self.tab.set_custom_headers(self.lua2python(headers, max_depth=3))
 
     @command()
-    def set_viewport(self, size):
-        if size is None:
-            return
-        return self.tab.set_viewport(size, raise_if_empty=True)
-
-    @command()
     def get_viewport_size(self):
         sz = self.tab.web_page.viewportSize()
-        return sz.width(), sz.height()
+        return {'width': sz.width(), 'height': sz.height()}
+
+    @command(table_argument=True)
+    def set_viewport(self, size):
+        size = self.lua2python(size)
+        if size is None:
+            # This is to simplify handling of window_size query argument: if it
+            # is not specified its value in Lua is `nil`.
+            return
+        elif isinstance(size, dict):
+            size = '%dx%d' % (size['width'], size['height'])
+        return self.tab.set_viewport(size, raise_if_empty=True)
 
     @command()
     def get_window_size(self):
         sz = self.tab.web_view.size()
-        return sz.width(), sz.height()
+        return {'width': sz.width(), 'height': sz.height()}
 
-    @command()
-    def set_window_size(self, sz):
-        self.tab.set_window_size(sz)
+    @command(table_argument=True)
+    def set_window_size(self, size):
+        size = self.lua2python(size)
+        self.tab.logger.log("lua window size: %s" % size)
+        if size is None:
+            # This is to simplify handling of window_size query argument: if it
+            # is not specified its value in Lua is `nil`.
+            return
+        elif isinstance(size, dict):
+            size = '%dx%d' % (size['width'], size['height'])
+        self.tab.set_window_size(size)
 
     @command()
     def set_images_enabled(self, enabled):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -283,12 +283,12 @@ class Splash(object):
         return self.tab.html()
 
     @command()
-    def png(self, width=None, height=None):
+    def png(self, width=None, height=None, render_all=False):
         if width is not None:
             width = int(width)
         if height is not None:
             height = int(height)
-        result = self.tab.png(width, height, b64=False)
+        result = self.tab.png(width, height, b64=False, render_all=render_all)
         return BinaryCapsule(result)
 
     @command()
@@ -448,27 +448,18 @@ class Splash(object):
     def set_custom_headers(self, headers):
         self.tab.set_custom_headers(self.lua2python(headers, max_depth=3))
 
-    @command()
+    @command(multiple_return_values=True)
     def get_viewport_size(self):
         sz = self.tab.web_page.viewportSize()
-        return {'width': sz.width(), 'height': sz.height()}
+        return [sz.width(), sz.height()]
 
     @command()
     def set_viewport_size(self, width, height):
-        return self.tab.set_viewport('%dx%d' % (width, height))
+        self.tab.set_viewport('%dx%d' % (width, height))
 
     @command()
     def set_viewport_full(self):
-        return self.tab.set_viewport('full', raise_if_empty=True)
-
-    @command()
-    def get_window_size(self):
-        sz = self.tab.web_view.size()
-        return {'width': sz.width(), 'height': sz.height()}
-
-    @command()
-    def set_window_size(self, width, height):
-        self.tab.set_window_size('%dx%d' % (width, height))
+        self.tab.set_viewport('full')
 
     @command()
     def set_images_enabled(self, enabled):

--- a/splash/render_options.py
+++ b/splash/render_options.py
@@ -121,6 +121,12 @@ class RenderOptions(object):
     def get_body(self):
         return self.get("body", None)
 
+    def get_render_all(self, wait=None):
+        result = self._get_bool("render_all", False)
+        if result == 1 and wait == 0:
+            raise BadOption("Pass non-zero 'wait' to render full webpage")
+        return result
+
     def get_lua_source(self):
         return self.get("lua_source")
 
@@ -156,25 +162,17 @@ class RenderOptions(object):
         return headers
 
     def get_viewport(self, wait=None):
-        viewport = self.get("viewport", self.get_window_size())
+        viewport = self.get("viewport", defaults.VIEWPORT_SIZE)
 
         if viewport == 'full':
             if wait == 0:
                 raise BadOption("Pass non-zero 'wait' to render full webpage")
         else:
             try:
-                validate_size_str(viewport, 'viewport')
+                validate_size_str(viewport)
             except ValueError as e:
                 raise BadOption(str(e))
         return viewport
-
-    def get_window_size(self):
-        window = self.get('window_size', defaults.WINDOW_SIZE)
-        try:
-            validate_size_str(window, 'window size')
-        except ValueError as e:
-            raise BadOption(str(e))
-        return window
 
     def get_filters(self, pool=None, adblock_rules=None):
         filter_names = self.get('filters', '')
@@ -213,7 +211,7 @@ class RenderOptions(object):
             'baseurl': self.get_baseurl(),
             'wait': wait,
             'viewport': self.get_viewport(wait),
-            'window_size': self.get_window_size(),
+            'render_all': self.get_render_all(wait),
             'images': self.get_images(),
             'headers': self.get_headers(),
             'proxy': self.get_proxy(),
@@ -239,7 +237,7 @@ class RenderOptions(object):
         )
 
 
-def validate_size_str(size_str, kind):
+def validate_size_str(size_str):
     """
     Validate size string in WxH format.
 
@@ -248,19 +246,17 @@ def validate_size_str(size_str, kind):
     wrong.
 
     :param size_str: string to validate
-    :param kind: 'viewport' or 'window size'
 
     """
-    max_width = defaults.WINDOW_MAX_WIDTH
-    max_heigth = defaults.WINDOW_MAX_HEIGTH
-    max_area = defaults.WINDOW_MAX_AREA
+    max_width = defaults.VIEWPORT_MAX_WIDTH
+    max_heigth = defaults.VIEWPORT_MAX_HEIGTH
+    max_area = defaults.VIEWPORT_MAX_AREA
     try:
         w, h = map(int, size_str.split('x'))
     except ValueError:
-        raise ValueError("Invalid %s format: %s" % (kind, size_str))
+        raise ValueError("Invalid viewport format: %s" % size_str)
     else:
         if not ((0 < w <= max_width) and (0 < h <= max_heigth) and
                 (w*h < max_area)):
-            raise ValueError("%s is out of range (%dx%d, area=%d)" %
-                             (kind.capitalize(), max_width, max_heigth,
-                              max_area))
+            raise ValueError("Viewport is out of range (%dx%d, area=%d)" %
+                             (max_width, max_heigth, max_area))

--- a/splash/tests/lua_modules/emulation.lua
+++ b/splash/tests/lua_modules/emulation.lua
@@ -22,8 +22,8 @@ function Splash:go_and_wait(args)
     error("'url' argument is required")
   end
   local wait = tonumber(args.wait)
-  if not wait and args.viewport == "full" then
-    error("non-zero 'wait' is required when viewport=='full'")
+  if not wait and (self.args.render_all or self.args.viewport == "full") then
+    error("non-zero 'wait' is required when rendering whole page")
   end
 
   self:set_images_enabled(self.args.images)

--- a/splash/tests/lua_modules/emulation.lua
+++ b/splash/tests/lua_modules/emulation.lua
@@ -28,6 +28,7 @@ function Splash:go_and_wait(args)
 
   self:set_images_enabled(self.args.images)
 
+  self:set_window_size(args.window_size)
   -- if viewport is 'full' it should be set only after waiting
   if args.viewport ~= "full" then
     self:set_viewport(args.viewport)

--- a/splash/tests/lua_modules/emulation.lua
+++ b/splash/tests/lua_modules/emulation.lua
@@ -28,16 +28,9 @@ function Splash:go_and_wait(args)
 
   self:set_images_enabled(self.args.images)
 
-  if args.window_size ~= nil then
-    w, h = string.match(args.window_size, '^(%d+)x(%d+)')
-    if w == nil or h == nil then
-      error('Invalid window size format: ' .. args.window_size)
-    end
-    self:set_window_size(tonumber(w), tonumber(h))
-  end
   -- if viewport is 'full' it should be set only after waiting
   if args.viewport ~= nil and args.viewport ~= "full" then
-    w, h = string.match(args.viewport, '^(%d+)x(%d+)')
+    local w, h = string.match(args.viewport, '^(%d+)x(%d+)')
     if w == nil or h == nil then
       error('Invalid viewport size format: ' .. args.viewport)
     end
@@ -55,10 +48,6 @@ function Splash:go_and_wait(args)
   end
 
   assert(self:_wait_restart_on_redirects(wait, 10))
-
-  if args.viewport == "full" then
-    self:set_viewport_full()
-  end
 end
 
 
@@ -102,9 +91,12 @@ end
 function emulation.render_png(splash)
   splash:go_and_wait(splash.args)
   splash:set_result_content_type("image/png")
+  local render_all = (splash.args.render_all or
+                      splash.args.viewport == "full")
   return splash:png{
     width=splash.args.width,
-    height=splash.args.height
+    height=splash.args.height,
+    render_all=render_all,
   }
 end
 

--- a/splash/tests/lua_modules/emulation.lua
+++ b/splash/tests/lua_modules/emulation.lua
@@ -28,10 +28,20 @@ function Splash:go_and_wait(args)
 
   self:set_images_enabled(self.args.images)
 
-  self:set_window_size(args.window_size)
+  if args.window_size ~= nil then
+    w, h = string.match(args.window_size, '^(%d+)x(%d+)')
+    if w == nil or h == nil then
+      error('Invalid window size format: ' .. args.window_size)
+    end
+    self:set_window_size(tonumber(w), tonumber(h))
+  end
   -- if viewport is 'full' it should be set only after waiting
-  if args.viewport ~= "full" then
-    self:set_viewport(args.viewport)
+  if args.viewport ~= nil and args.viewport ~= "full" then
+    w, h = string.match(args.viewport, '^(%d+)x(%d+)')
+    if w == nil or h == nil then
+      error('Invalid viewport size format: ' .. args.viewport)
+    end
+    self:set_viewport_size(tonumber(w), tonumber(h))
   end
 
   local ok, reason = self:go{url=url, baseurl=args.baseurl}
@@ -47,7 +57,7 @@ function Splash:go_and_wait(args)
   assert(self:_wait_restart_on_redirects(wait, 10))
 
   if args.viewport == "full" then
-    self:set_viewport(args.viewport)
+    self:set_viewport_full()
   end
 end
 

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -1858,34 +1858,36 @@ end
         end
         """
         out = self.return_json_from_lua(script)
-        self.assertEqual(out,
-                         {'width': 1366, 'height': 768})
+        w, h = map(int, defaults.VIEWPORT_SIZE.split('x'))
+        self.assertEqual(out, {'width': w, 'height': h})
 
     def test_default_dimensions(self):
         self.assertSizeAfter("",
-                             {'inner': '1366x768',
-                              'outer': '1366x768',
-                              'client': '1366x768'})
+                             {'inner': defaults.VIEWPORT_SIZE,
+                              'outer': defaults.VIEWPORT_SIZE,
+                              'client': defaults.VIEWPORT_SIZE})
 
     def test_set_sizes_as_table(self):
         self.assertSizeAfter('splash:set_viewport_size{width=111, height=222}',
                              {'inner': '111x222',
-                              'outer': '1366x768',
+                              'outer': defaults.VIEWPORT_SIZE,
                               'client': '111x222'})
         self.assertSizeAfter('splash:set_viewport_size{height=333, width=444}',
                              {'inner': '444x333',
-                              'outer': '1366x768',
+                              'outer': defaults.VIEWPORT_SIZE,
                               'client': '444x333'})
 
     def test_viewport_size_roundtrips(self):
         self.assertSizeAfter(
             'splash:set_viewport_size(splash:get_viewport_size())',
-            {'inner': '1366x768', 'outer': '1366x768', 'client': '1366x768'})
+            {'inner': defaults.VIEWPORT_SIZE,
+             'outer': defaults.VIEWPORT_SIZE,
+             'client': defaults.VIEWPORT_SIZE})
 
     def test_viewport_size(self):
         self.assertSizeAfter('splash:set_viewport_size(2000, 2000)',
                              {'inner': '2000x2000',
-                              'outer': '1366x768',
+                              'outer': defaults.VIEWPORT_SIZE,
                               'client': '2000x2000'})
 
     def test_viewport_size_validation(self):
@@ -1927,12 +1929,12 @@ end
             self.assertRaisesRegexp(RuntimeError, errmsg, run_test, size_str)
 
     def test_viewport_full(self):
-        w = int('1366x768'.split('x')[0])
+        w = int(defaults.VIEWPORT_SIZE.split('x')[0])
         self.assertSizeAfter('splash:go(splash.args.url);'
                              'splash:wait(0.1);'
                              'splash:set_viewport_full();',
                              {'inner': '%dx2000' % w,
-                              'outer': '1366x768',
+                              'outer': defaults.VIEWPORT_SIZE,
                               'client': '%dx2000' % w},
                              url=self.mockurl('tall'))
 

--- a/splash/tests/test_execute_emulation.py
+++ b/splash/tests/test_execute_emulation.py
@@ -60,24 +60,6 @@ class EmulatedMetaRedirectTest(Base.EmulationMixin, test_redirects.MetaRedirectT
 class EmulatedRenderPngTest(Base.EmulationMixin, test_render.RenderPngTest):
     script = 'main = require("emulation").render_png'
 
-    # TODO: default width and height are not applied
-    @pytest.mark.xfail
-    def test_ok(self):
-        super(EmulatedRenderPngTest, self).test_ok()
-
-    @pytest.mark.xfail
-    def test_ok_https(self):
-        super(EmulatedRenderPngTest, self).test_ok_https()
-
-    # TODO: fix validation
-    @pytest.mark.xfail
-    def test_viewport_out_of_bounds(self):
-        super(EmulatedRenderPngTest, self).test_viewport_out_of_bounds()
-
-    @pytest.mark.xfail
-    def test_viewport_invalid(self):
-        super(EmulatedRenderPngTest, self).test_viewport_invalid()
-
     @pytest.mark.xfail(
         run=False,
         reason="""

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -291,8 +291,12 @@ class RenderPngTest(Base.RenderTest):
     def test_viewport_full_wait(self):
         r = self.request({'url': self.mockurl("jsrender"), 'viewport': 'full'})
         self.assertStatusCode(r, 400)
+        r = self.request({'url': self.mockurl("jsrender"), 'render_all': 1})
+        self.assertStatusCode(r, 400)
 
         r = self.request({'url': self.mockurl("jsrender"), 'viewport': 'full', 'wait': 0.1})
+        self.assertStatusCode(r, 200)
+        r = self.request({'url': self.mockurl("jsrender"), 'render_all': 1, 'wait': 0.1})
         self.assertStatusCode(r, 200)
 
     def test_viewport_invalid(self):
@@ -309,6 +313,15 @@ class RenderPngTest(Base.RenderTest):
         r = self.request({'url': self.mockurl("tall"), 'viewport': 'full', 'wait': 0.1})
         self.assertPng(r, height=2000)  # 2000px is hardcoded in that html
 
+    def test_render_all(self):
+        r = self.request({'url': self.mockurl("tall"), 'render_all': 1, 'wait': 0.1})
+        self.assertPng(r, height=2000)  # 2000px is hardcoded in that html
+
+    def test_render_all_with_viewport(self):
+        r = self.request({'url': self.mockurl("tall"), 'viewport': '2000x1000',
+                          'render_all': 1, 'wait': 0.1})
+        self.assertPng(r, width=2000, height=2000)
+
     def test_images_enabled(self):
         r = self.request({'url': self.mockurl("show-image"), 'viewport': '100x100'})
         self.assertPixelColor(r, 30, 30, (0,0,0,255))
@@ -319,7 +332,7 @@ class RenderPngTest(Base.RenderTest):
 
     def test_very_long_green_page(self):
         r = self.request({'url': self.mockurl("very-long-green-page"),
-                          'viewport': 'full', 'wait': '0.01'})
+                          'render_all': 1, 'wait': '0.01'})
         self.assertPng(r, height=60000)  # hardcoded in the html
         self.assertPixelColor(r, 0, 59999, (0x00, 0xFF, 0x77, 0xFF))
 

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -280,7 +280,7 @@ class RenderPngTest(Base.RenderTest):
 
     def _test_ok(self, url):
         r = self.request({"url": url})
-        self.assertPng(r, width=1024, height=768)
+        self.assertPng(r, width=1366, height=768)
 
     def test_width(self):
         r = self.request({"url": self.mockurl("jsrender"), "width": "300"})

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -193,6 +193,18 @@ class RenderHtmlTest(Base.RenderTest):
         self.assertStatusCode(r, 200)
         self.assertIn('300x400', r.text)
 
+    def test_window_size(self):
+        r = self.request({'url': self.mockurl('jsviewport'),
+                          'window_size': '300x400'})
+        self.assertStatusCode(r, 200)
+        self.assertIn('300x400', r.text)
+
+    def test_window_size_and_viewport(self):
+        r = self.request({'url': self.mockurl('jsviewport'),
+                          'window_size': '1000x1000', 'viewport': '300x400'})
+        self.assertStatusCode(r, 200)
+        self.assertIn('300x400', r.text)
+
     def test_nonascii_url(self):
         nonascii_value =  u'тест'.encode('utf8')
         url = self.mockurl('getrequest') + '?param=' + nonascii_value
@@ -295,6 +307,16 @@ class RenderPngTest(Base.RenderTest):
     def test_viewport_invalid(self):
         for viewport in ['foo', '1xfoo', 'axe', '-1x300']:
             r = self.request({'url': self.mockurl("jsrender"), 'viewport': viewport})
+            self.assertStatusCode(r, 400)
+
+    def test_window_size_invalid(self):
+        for window_size in ['foo', '1xfoo', 'axe', '-1x300']:
+            r = self.request({'url': self.mockurl("jsrender"), 'window_size': window_size})
+            self.assertStatusCode(r, 400)
+
+    def test_window_size_out_of_bounds(self):
+        for window_size in ['99999x1', '1x99999', '9000x9000']:
+            r = self.request({'url': self.mockurl("jsrender"), 'window_size': window_size})
             self.assertStatusCode(r, 400)
 
     def test_viewport_out_of_bounds(self):

--- a/splash/xvfb.py
+++ b/splash/xvfb.py
@@ -34,7 +34,7 @@ def _get_xvfb():
 
     try:
         from xvfbwrapper import Xvfb
-        width, height = map(int, defaults.VIEWPORT.split("x"))
+        width, height = map(int, defaults.WINDOW_SIZE.split("x"))
         return Xvfb(width, height)
     except ImportError:
         return None

--- a/splash/xvfb.py
+++ b/splash/xvfb.py
@@ -34,7 +34,7 @@ def _get_xvfb():
 
     try:
         from xvfbwrapper import Xvfb
-        width, height = map(int, defaults.WINDOW_SIZE.split("x"))
+        width, height = map(int, defaults.VIEWPORT_SIZE.split("x"))
         return Xvfb(width, height)
     except ImportError:
         return None


### PR DESCRIPTION
This is yet another attempt at #131.

The problem was that when "viewport=full" was selected,
viewport was not resized till the very rendering and inherited the
default window size which is small (640x480).  In presence of so called
fluid layouts this could significantly affect the appearance of the site (see #150 and #145)
and there was no way to tweak that initial size, because "viewport="
argument was already occupied with "viewport=full".

This PR does the following:

* ~~add "window_size=" query argument to "render.xyz" endpoints so that one can simultaneously select full viewport and tweak the window size~~

* ~~add "splash:set_window_size" function to Lua environment~~

* add `render_all=1` query argument to "render.xyz", so that one can simultaneously select full viewport and tweak the window size

* add `render_all` flag to `splash:png` function available in Lua scripts

* increase default window size from 640x480 to ~1024x768~ 1366x768

* if "splash:set_viewport('full')" fails in Lua environment, raise an
  error instead of silently falling back to default size


TODO:
- [x] bump Lua documentation
- [x] fix tests