### PR TITLE
Refactor handling of multiple return values from Lua commands

### DIFF
--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -1,15 +1,35 @@
+-- This function works very much like standard Lua assert, but:
 --
--- Python Splash commands return `ok, result` pairs; this decorator
--- raises an error if "ok" is false and returns "result" otherwise.
+-- * the first argument is the stack level to report the error at (1 being
+--   current level, like for `error` function)
+-- * it strips the flag if it evaluates to true
+-- * it does not take a message parameter and thus will always preserve all
+--   elements of the tuple
+--
+local function assertx(nlevels, ok, ...)
+  if not ok then
+    error(select(1, ...), 1 + nlevels)
+  else
+    return ...
+  end
+end
+
+
+--
+-- Python Splash commands return
+--
+--     ok, result1, [ result2, ... ]
+--
+-- tuples.  If "ok" is false, this decorator raises an error using "result1" as
+-- message.  Otherwise, it returns
+--
+--     result1, [result2, ...]
 --
 local function unwraps_errors(func)
   return function(...)
-    local ok, result = func(...)
-    if not ok then
-      error(result, 2)
-    else
-      return result
-    end
+    -- Here assertx is tail-call-optimized and extra stack level is not
+    -- created, hence nlevels==1.
+    return assertx(1, func(...))
   end
 end
 
@@ -51,24 +71,6 @@ end
 
 
 --
--- This decorator expects function return value to be a Python list
--- and unpacks it to Lua multiple return values.
---
-local function unpacks_multiple_return_values(func)
-  return function(...)
-    -- Max allowed list size is 2; it is enough for functions which return
-    -- error flag along with a value. This trick is needed to handle `nil` as a
-    -- first value correctly.
-    --
-    -- Max size used to be 10, but it created full 10-element tuples which,
-    -- when passed through lupa, causing errors in Python runtime, because
-    -- Python callables, unlike Lua ones, are strict about the number of
-    -- arguments.
-    return table.unpack(func(...), 1, 2)
-  end
-end
-
---
 -- Lua wrapper for Splash Python object.
 --
 -- It hides attributes that should not be exposed,
@@ -92,10 +94,6 @@ function Splash.create(py_splash)
 
     if opts.is_async then
       command = yields_result(command)
-    end
-
-    if opts.multiple_return_values then
-      command = unpacks_multiple_return_values(command)
     end
 
     self[key] = command


### PR DESCRIPTION
This PR revisits returning multiple values from splash commands exported to Lua.

* It drops `unpacks_multiple_return_values` flag as it is unnecessary: tuples
  will be returned as Lua pseudo-tuples, lists will be returned as tables following `lupa` convention

* pseudo-tuples will contain the exact number of elements that were in
  their Python equivalent, regardless of None/nil values.

TODO:
- [x] ~~maybe there's a way to test arbitrary commands, like those that return `None`, lists or dicts as one of their return values~~ not worth it
- [x] I couldn't verify that tracebacks do not include code from `splash.lua`, because of issues with pcall (they deserve a separate issue)