### PR TITLE
Fix width scaling

### DIFF
--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -969,8 +969,8 @@ Example:
 .. code-block:: lua
 
      function main(splash)
-         assert(splash:go("http://example.com"))
          splash:set_viewport_size(1980, 1020)
+         assert(splash:go("http://example.com"))
          return {png=splash:png()}
      end
 

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -115,6 +115,18 @@ TallPage = _html_resource("""
 </html>
 """)
 
+RedGreenPage = _html_resource("""
+<html>
+  <style type="text/css" media="screen">
+    * { padding: 0px; margin: 0px }
+    #left { float:left; width: 50%%; height: 100%%; background-color: #ff0000 }
+    #right { float:left; width: 50%%; height: 100%%; background-color: #00ff00 }
+  </style>
+<body>
+  <div id="left">&nbsp;</div><div id="right">&nbsp;</div>
+</body>
+</html>
+""")
 
 BadRelatedResource = _html_resource("""
 <html>
@@ -592,6 +604,7 @@ class Root(Resource):
         self.putChild("jsinterval", JsInterval())
         self.putChild("jsviewport", JsViewport())
         self.putChild("tall", TallPage())
+        self.putChild("red-green", RedGreenPage())
         self.putChild("baseurl", BaseUrl())
         self.putChild("delay", Delay())
         self.putChild("slow.gif", SlowImage())


### PR DESCRIPTION
This should fix #166.

The old code was broken, because painter.setClipRect operates in input
coordinates, but it was fed with clip region in outer coordinates.