### PR TITLE
Make Lua viewport resize commands trigger a page relayout

### DIFF
--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -619,9 +619,9 @@ specified one without resizing the content.  The region created by such
 extension is transparent.
 
 To set the viewport size use :ref:`splash-set-viewport-size`,
-:ref:`splash-set-viewport-full` or *render_all* argument.  *render_all=true* is
-equivalent to running ``splash:set_viewport_full()`` just before the rendering
-and restoring the viewport size afterwards.
+:ref:`splash-set-viewport-full` or *render_all* argument.  ``render_all=true``
+is equivalent to running ``splash:set_viewport_full()`` just before the
+rendering and restoring the viewport size afterwards.
 
 *scale_method* parameter must be either ``'raster'`` or ``'vector'``.  When
 ``scale_method='raster'``, the image is resized per-pixel.  When
@@ -990,11 +990,12 @@ Example:
 
 .. note::
 
-   This will affect ``window.innerWidth`` and ``window.innerHeight`` JS
-   variables and invoke ``window.onresize`` event callback.  However this will
-   only happen during the next asynchronous operation and :ref:`splash-png` is
-   notably synchronous, so if you have resized a page and want it to react
-   accordingly before taking the screenshot, use :ref:`splash-wait`.
+   This will relayout all document elements and affect geometry variables, such
+   as ``window.innerWidth`` and ``window.innerHeight``.  However
+   ``window.onresize`` event callback will only be invoked during the next
+   asynchronous operation and :ref:`splash-png` is notably synchronous, so if
+   you have resized a page and want it to react accordingly before taking the
+   screenshot, use :ref:`splash-wait`.
 
 .. _splash-set-viewport-full:
 
@@ -1011,6 +1012,8 @@ Resize browser viewport to fit the whole page.
 some time passed after that (use :ref:`splash-wait`). This is an unfortunate
 restriction, but it seems that this is the only way to make automatic resizing
 work reliably.
+
+See :ref:`splash-set-viewport-size` for a note about interaction with JS.
 
 :ref:`splash-png` uses the viewport size.
 

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -145,6 +145,13 @@ class BrowserTab(QObject):
         Set viewport size.
         If size is "full" viewport size is detected automatically.
         If can also be "<width>x<height>".
+
+        .. note::
+
+           This will update all JS geometry variables, but window resize event
+           is delivered asynchronously and so ``window.resize`` will not be
+           invoked until control is yielded to the event loop.
+
         """
         if size == 'full':
             size = self.web_page.mainFrame().contentsSize()
@@ -162,9 +169,21 @@ class BrowserTab(QObject):
             w, h = map(int, size.split('x'))
             size = QSize(w, h)
         self.web_page.setViewportSize(size)
+        self._force_relayout()
         w, h = int(size.width()), int(size.height())
         self.logger.log("viewport size is set to %sx%s" % (w, h), min_level=2)
         return w, h
+
+    def _force_relayout(self):
+        """Force a relayout of the web page contents."""
+        # setPreferredContentsSize may be used to force a certain size for
+        # layout purposes.  Passing an invalid size resets the override and
+        # tells the QWebPage to use the size as requested by the document.
+        # This is in fact the default behavior, so we don't change anything.
+        #
+        # The side-effect of this operation is a forced synchronous relayout of
+        # the page.
+        self.web_page.setPreferredContentsSize(QSize())
 
     def lock_navigation(self):
         self.web_page.navigation_locked = True

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -1984,6 +1984,28 @@ end
         img = Image.open(StringIO(standard_b64decode(out['png'])))
         self.assertEqual(img.size, (w, 2000))
 
+    def test_set_viewport_size_changes_contents_size_immediately(self):
+        # GH167
+        script = """
+function main(splash)
+splash:set_viewport_size(1024, 768)
+assert(splash:set_content([[
+<html>
+<body style="min-width: 800px; margin: 0px">&nbsp;</body>
+</html>
+]]))
+result = {}
+result.before = {splash:set_viewport_full()}
+splash:set_viewport_size(640, 480)
+result.after = {splash:set_viewport_full()}
+return result
+end
+        """
+        out = self.return_json_from_lua(script)
+        self.assertEqual(out,
+                         {'before': {'1': 1024, '2': 768},
+                          'after': {'1': 800, '2': 480}})
+
     @pytest.mark.xfail
     def test_viewport_full_raises_error_if_fails_in_script(self):
         # XXX: for local resources loadFinished event generally arrives after

--- a/splash/tests/utils.py
+++ b/splash/tests/utils.py
@@ -115,6 +115,7 @@ class MockServer(object):
         )
         for port in (self.http_port, self.https_port, self.proxy_port):
             _wait_for_port(port)
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.proc.kill()


### PR DESCRIPTION
This PR makes `splash:set_viewport_size` and `splash:set_viewport_full` operations synchronous w.r.t. Lua runtime. This should fix #167.

~~This is achieved by adding `qtutils.process_pending_events` function and using it in respective `Splash` commands. Internally visible `BrowserTab.set_viewport` is unchanged, because it seems desirable for the page not to react to temporary viewport resizes performed by `png` rendering methods, so we have to maintain some way to get the old behaviour. Also, python code unlike Lua scripts has access to `process_pending_events` which can be used whenever it is necessary.~~

This is achieved by using `QWebPage.setPreferredContentsSize` that triggers a synchronous relayout of the page's elements (but does not propagate values to JS). `process_pending_events`-based solution was technically synchronous, too, but it could for example carry out a redirect in response to an event  scheduled for the same time.