### PR TITLE
Allow to enable/disable JavaScript  #191

### DIFF
--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -331,6 +331,44 @@ Compare:
 See also: :ref:`splash-runjs`, :ref:`splash-jsfunc`,
 :ref:`splash-wait-for-resume`, :ref:`splash-autoload`.
 
+.. _splash-enable_js:
+
+splash:enable_js
+------------
+
+Enables javascript for the browser.
+
+**Signature:** ``splash:enable_js()``
+
+Example:
+
+.. code-block:: lua
+
+    splash:enable_js()
+    assert(splash:go('https://www.whatismybrowser.com/is-javascript-enabled'))
+
+See also: :ref:`splash-disable_js`, :ref:`splash-runjs`, :ref:`splash-jsfunc`,
+:ref:`splash-evaljs`.
+
+.. _splash-enable_js:
+
+splash:disable_js
+------------
+
+Disables javascript for the browser.
+
+**Signature:** ``splash:disable_js()``
+
+Example:
+
+.. code-block:: lua
+
+    splash:disable_js()
+    assert(splash:go('https://www.whatismybrowser.com/is-javascript-enabled'))
+
+See also: :ref:`splash-enable_js`, :ref:`splash-runjs`, :ref:`splash-jsfunc`,
+:ref:`splash-evaljs`.
+
 .. _splash-runjs:
 
 splash:runjs

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -548,6 +548,16 @@ class BrowserTab(QObject):
         js_source = "%s;undefined" % js_source
         self.evaljs(js_source, handle_errors=handle_errors)
 
+	def enable_js(self):
+		""" Enables Javascript """
+		settings = self.web_page.settings()
+		settings.setAttribute(QWebSettings.JavascriptEnabled, True)
+
+	def disable_js(self):
+		""" Disables Javascript """
+		settings = self.web_page.settings()
+		settings.setAttribute(QWebSettings.JavascriptEnabled, False)
+
     def wait_for_resume(self, js_source, callback, errback, timeout):
         """
         Run some Javascript asynchronously.

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -548,15 +548,15 @@ class BrowserTab(QObject):
         js_source = "%s;undefined" % js_source
         self.evaljs(js_source, handle_errors=handle_errors)
 
-	def enable_js(self):
-		""" Enables Javascript """
-		settings = self.web_page.settings()
-		settings.setAttribute(QWebSettings.JavascriptEnabled, True)
+    def enable_js(self):
+        """ Enables Javascript """
+        settings = self.web_page.settings()
+        settings.setAttribute(QWebSettings.JavascriptEnabled, True)
 
-	def disable_js(self):
-		""" Disables Javascript """
-		settings = self.web_page.settings()
-		settings.setAttribute(QWebSettings.JavascriptEnabled, False)
+    def disable_js(self):
+        """ Disables Javascript """
+        settings = self.web_page.settings()
+        settings.setAttribute(QWebSettings.JavascriptEnabled, False)
 
     def wait_for_resume(self, js_source, callback, errback, timeout):
         """

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -313,13 +313,13 @@ class Splash(object):
         except JsError as e:
             return None, e.args[0]
 
-	@command()
-	def enable_js(self):
-		self.tab.enable_js()
+    @command()
+    def enable_js(self):
+        self.tab.enable_js()
 
-	@command()
-	def disable_js(self):
-		self.tab.disable_js()
+    @command()
+    def disable_js(self):
+        self.tab.disable_js()
 
     @command(async=True, can_raise_async=True)
     def wait_for_resume(self, snippet, timeout=0):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -313,6 +313,14 @@ class Splash(object):
         except JsError as e:
             return None, e.args[0]
 
+	@command()
+	def enable_js(self):
+		self.tab.enable_js()
+
+	@command()
+	def disable_js(self):
+		self.tab.disable_js()
+
     @command(async=True, can_raise_async=True)
     def wait_for_resume(self, snippet, timeout=0):
         cmd_id = next(self._command_ids)

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -2037,8 +2037,8 @@ class SetContentTest(BaseLuaRenderTest):
         self.assertStatusCode(resp, 200)
         img = Image.open(StringIO(resp.content))
         self.assertNotEqual((0,0,0,255), img.getpixel((10, 10)))
-        
-	def test_enable_js(self):
+
+    def test_enable_js(self):
         script = """
         function main(splash)
             splash:disable_js()

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -16,7 +16,6 @@ from . import test_render
 from .test_jsonpost import JsonPostRequestHandler
 from .utils import NON_EXISTING_RESOLVABLE, SplashServer
 from .mockserver import JsRender
-from .mockserver import JsBG
 from .. import defaults
 
 


### PR DESCRIPTION
- browser_tab supports enable/disable Javascript. (`enable_js()`,` disable_js()`)
- qtrender_lua can invoke enable_js,disable_js
- documentation
- tests written (successful)