### PR TITLE
On response headers

### DIFF
--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -1563,7 +1563,7 @@ request to Splash:
 .. _splash-on-response-headers:
 
 splash:on_response_headers
------------------
+--------------------------
 
 Register a function to be called after response headers are received, before 
 response body is read.
@@ -1582,14 +1582,23 @@ response body is read.
 * ``info`` - a table with response data in `HAR response`_ format
 * ``request`` - a table with request information 
 
+
 These fields are for information only; changing them doesn't change
 response received by splash. ``response`` has following methods:
 
 * ``response:abort()`` - aborts reading of response body
 
 A callback passed to :ref:`splash-on-response-headeers` can't call Splash
-async methods like :ref:`splash-wait` or :ref:`splash-go`. ``response`` cannot
-is cleared after exiting from callback, so you cannot use it outside callback.
+async methods like :ref:`splash-wait` or :ref:`splash-go`. ``response`` object
+is deleted after exiting from callback, so you cannot use it outside callback.
+
+``response.request`` available in callback contains following attributes:
+
+* ``url`` - requested URL - can be different from response URL in case there is
+  redirect
+* ``headers`` - HTTP headers of request
+* ``method`` HTTP method of request
+* ``cookies`` - cookies in .har format
 
 Example 1 - log content-type headers of all responses received while rendering
 

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -1560,6 +1560,80 @@ request to Splash:
 
     `splash:on_request` method doesn't support named arguments.
 
+.. _splash-on-response-headers:
+
+splash:on_response_headers
+-----------------
+
+Register a function to be called after response headers are received, before 
+response body is read.
+
+**Signature:** ``splash:on_response_headers(callback)``
+
+**Returns:** nil.
+
+**Async:** no.
+
+:ref:`splash-on-response-headers` callback receives a single ``response`` argument.
+``response`` contains following fields:
+
+* ``url`` - requested URL;
+* ``headers`` - HTTP headers of response
+* ``info`` - a table with response data in `HAR response`_ format
+* ``request`` - a table with request information 
+
+These fields are for information only; changing them doesn't change
+response received by splash. ``response`` has following methods:
+
+* ``response:abort()`` - aborts reading of response body
+
+A callback passed to :ref:`splash-on-response-headeers` can't call Splash
+async methods like :ref:`splash-wait` or :ref:`splash-go`. ``response`` cannot
+is cleared after exiting from callback, so you cannot use it outside callback.
+
+Example 1 - log content-type headers of all responses received while rendering
+
+.. code-block:: lua
+
+    function main(splash)
+        local all_headers = {}
+        splash:on_response_headers(function(response)
+            local content_type = response.headers["Content-Type"]
+            all_headers[response.url] = content_type
+        end)
+        assert(splash:go(splash.args.url))
+        return all_headers
+    end
+    
+Example 2 - abort reading body of all responses with content type ``text/css``
+
+.. code-block:: lua
+
+    function main(splash)
+        splash:on_response_headers(function(response)
+            local content_type = response.headers["Content-Type"]
+            if content_type == "text/css" then
+                response.abort()
+            end
+        end)
+        assert(splash:go(splash.args.url))
+        return splash:png()
+    end
+
+Example 3 - extract all cookies set by website without reading response body
+
+.. code-block:: lua
+
+    function main(splash)
+        local cookies = ""
+        splash:on_response_headers(function(response)
+            local response_cookies = response.headers["Set-cookie"]
+            cookies = cookies .. ";" .. response_cookies
+            response.abort()
+        end)
+        assert(splash:go(splash.args.url))
+        return cookies
+    end
 
 .. _splash-args:
 

--- a/splash/har/qt.py
+++ b/splash/har/qt.py
@@ -95,6 +95,8 @@ def reply2har(reply, include_content=False, binary_content=False):
         },
         "headersSize" : headers_size(reply),
         "ok": not reply.error(),  # non-standard but useful
+        "method": OPERATION_NAMES.get(reply.operation(), '?'),
+        "url": unicode(reply.url().toString())
     }
 
     content_type = reply.header(QNetworkRequest.ContentTypeHeader)

--- a/splash/har/qt.py
+++ b/splash/har/qt.py
@@ -94,8 +94,10 @@ def reply2har(reply, include_content=False, binary_content=False):
             "mimeType": "",
         },
         "headersSize" : headers_size(reply),
-        "ok": not reply.error(),  # non-standard but useful
-        "method": OPERATION_NAMES.get(reply.operation(), '?'),
+        # non-standard but useful
+        "ok": not reply.error(),
+        # non-standard, useful because reply url may not equal request url
+        # in case of redirect
         "url": unicode(reply.url().toString())
     }
 

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -226,9 +226,26 @@ end
 local Response = {}
 Response.__index = Response
 
+function Response._create(py_reply)
+    local self = {response=py_reply.response}
+    setmetatable(self, Request)
+    
+    for key, opts in pairs(py_reply.commands) do
+        local command = py_reply[key]
+        command = drops_self_argument(command)
+
+        if opts.returns_error_flag then
+            command = unwraps_errors(command)
+        end
+        self[key] = command
+    end
+    
+    return self
+end
+
 function Splash:on_response_headers(cb)
     private.on_response_headers(self, function (response)
-        local res = Response._modify_headers(response)
+        local res = Response._create(response)
         return cb(res)
     end)
 end

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -227,7 +227,11 @@ local Response = {}
 Response.__index = Response
 
 function Response._create(py_reply)
-    local self = {response=py_reply.response}
+    local self = {headers=py_reply.headers}
+
+    for key, value in pairs(py_reply.headers) do 
+        self[key] = value
+    end
     
     for key, opts in pairs(py_reply.commands) do
         local command = py_reply[key]

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -229,16 +229,24 @@ Response.__index = Response
 function Response._create(py_reply)
     local self = {
         headers=py_reply.headers,
-        info=py_reply.info
+        info=py_reply.info,
+        request=py_reply.request
     }
 
     setmetatable(self, Response)
+    
+    -- convert har headers to something more convenient
+    _request_headers = {}
+    for name, value in pairs(py_reply.request["headers"]) do
+        _request_headers[value["name"]] = value["value"]
+    end
+    py_reply.request["headers"] = _request_headers
 
     -- take some keys from py_reply.info 
     -- but not all (we don't want mess har headers with response headers)
-    local keys_from_info = {"status", "url", "method", "ok"}
+    local keys_from_reply_info = {"status", "url", "ok"}
 
-    for key, value in pairs(keys_from_info) do 
+    for key, value in pairs(keys_from_reply_info) do 
         self[value] = py_reply.info[value]
     end
     

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -227,7 +227,14 @@ local Response = {}
 Response.__index = Response
 
 function Response._create(py_reply)
-    local self = {headers=py_reply.headers}
+    local self = {
+        headers=py_reply.headers,
+        url=py_reply.url,
+        status=py_reply.status,
+        info=py_reply.info
+    }
+
+    setmetatable(self, Response)
 
     for key, value in pairs(py_reply.headers) do 
         self[key] = value

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -229,15 +229,17 @@ Response.__index = Response
 function Response._create(py_reply)
     local self = {
         headers=py_reply.headers,
-        url=py_reply.url,
-        status=py_reply.status,
         info=py_reply.info
     }
 
     setmetatable(self, Response)
 
-    for key, value in pairs(py_reply.headers) do 
-        self[key] = value
+    -- take some keys from py_reply.info 
+    -- but not all (we don't want mess har headers with response headers)
+    local keys_from_info = {"status", "url", "method", "ok"}
+
+    for key, value in pairs(keys_from_info) do 
+        self[value] = py_reply.info[value]
     end
     
     for key, opts in pairs(py_reply.commands) do

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -236,7 +236,7 @@ function Response._create(py_reply)
     setmetatable(self, Response)
     
     -- convert har headers to something more convenient
-    _request_headers = {}
+    local _request_headers = {}
     for name, value in pairs(py_reply.request["headers"]) do
         _request_headers[value["name"]] = value["value"]
     end

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -228,7 +228,6 @@ Response.__index = Response
 
 function Response._create(py_reply)
     local self = {response=py_reply.response}
-    setmetatable(self, Request)
     
     for key, opts in pairs(py_reply.commands) do
         local command = py_reply[key]

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -223,5 +223,15 @@ function Splash:on_request(cb)
   end)
 end
 
+local Response = {}
+Response.__index = Response
+
+function Splash:on_response_headers(cb)
+    private.on_response_headers(self, function (response)
+        local res = Response._modify_headers(response)
+        return cb(res)
+    end)
+end
+
 
 return Splash

--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -268,8 +268,7 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
         self.log("Finished downloading {url}", reply)
 
     def _handleMetaData(self):
-        """Signal emitted before response body is reader, after
-        first bytes of response are read (e.g. we get response headers).
+        """Signal emitted before reading response body, after getting headers
         """
         reply = self.sender()
         self._handle_reply_cookies(reply)

--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -27,6 +27,7 @@ from splash.request_middleware import (
 from splash.response_middleware import ContentTypeMiddleware
 from splash import defaults
 
+
 def create_default(filters_path=None, verbosity=None, allowed_schemes=None):
     verbosity = defaults.VERBOSITY if verbosity is None else verbosity
     if allowed_schemes is None:
@@ -241,6 +242,7 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
 
     def _handleFinished(self):
         reply = self.sender()
+
         har_entry = self._harEntry()
         if har_entry is not None:
             har_entry["_tmp"]["state"] = self.REQUEST_FINISHED
@@ -267,7 +269,14 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
 
     def _handleMetaData(self):
         reply = self.sender()
+        # reply.setRawHeader("foo", "bar")
         self._handle_reply_cookies(reply)
+
+        callbacks = self._getWebPageAttribute(reply.request(), "callbacks")
+
+        if callbacks and "on_response_headers" in callbacks:
+            for cb in callbacks["on_response_headers"]:
+                cb(reply)
 
         har_entry = self._harEntry()
         if har_entry is not None:
@@ -333,6 +342,7 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
 
         msg = msg.format(url=url)
         log.msg(msg, system='network-manager')
+
 
 class SplashQNetworkAccessManager(ProxiedQNetworkAccessManager):
     """

--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -280,6 +280,9 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
                 try:
                     cb(reply)
                 except:
+                    # TODO unhandled exceptions in lua callbacks
+                    # should we raise errors here?
+                    # https://github.com/scrapinghub/splash/issues/161
                     self.log("error in on_response_headers callback", min_level=1)
                     self.log(traceback.format_exc(), min_level=1)
 

--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -276,7 +276,11 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
 
         if callbacks and "on_response_headers" in callbacks:
             for cb in callbacks["on_response_headers"]:
-                cb(reply)
+                try:
+                    cb(reply)
+                except:
+                    self.log("error in on_response_headers callback", min_level=1)
+                    self.log(traceback.format_exc(), min_level=1)
 
         har_entry = self._harEntry()
         if har_entry is not None:

--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -118,6 +118,7 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
 
             reply.error.connect(self._handleError)
             reply.finished.connect(self._handleFinished)
+            # http://doc.qt.io/qt-5/qnetworkreply.html#metaDataChanged
             reply.metaDataChanged.connect(self._handleMetaData)
             reply.downloadProgress.connect(self._handleDownloadProgress)
 
@@ -242,7 +243,6 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
 
     def _handleFinished(self):
         reply = self.sender()
-
         har_entry = self._harEntry()
         if har_entry is not None:
             har_entry["_tmp"]["state"] = self.REQUEST_FINISHED
@@ -268,8 +268,10 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
         self.log("Finished downloading {url}", reply)
 
     def _handleMetaData(self):
+        """Signal emitted before response body is reader, after
+        first bytes of response are read (e.g. we get response headers).
+        """
         reply = self.sender()
-        # reply.setRawHeader("foo", "bar")
         self._handle_reply_cookies(reply)
 
         callbacks = self._getWebPageAttribute(reply.request(), "callbacks")

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -759,11 +759,8 @@ class _WrappedResponse(object):
         self._exceptions = []
 
     @command()
-    def set_header(self, name, value):
-        self.response.setRawHeader(name, value)
-        # doesn't work because
-        # lupa._lupa.LuaError: [string "..."]:4: RuntimeError('no access to protected functions or signals for objects not created from Python',)
-        # need to find some other way
+    def abort(self):
+        self.response.abort()
 
 
 class SplashScriptRunner(BaseScriptRunner):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -763,7 +763,7 @@ def wrapped_response(lua, reply):
 
 class _WrappedResponse(object):
     _attribute_whitelist = [
-        'commands', "headers", "response", "url", "status", "info"
+        'commands', "headers", "response",  "info"
     ]
 
     def __init__(self, lua, response):
@@ -773,17 +773,11 @@ class _WrappedResponse(object):
         # https://github.com/kennethreitz/requests/issues/1926#issuecomment-35524028
         _headers = {str(k): str(v) for k, v in response.rawHeaderPairs()}
         self.headers = self.lua.python2lua(_headers)
-        url = response.url().toString()
-        self.url = self.lua.python2lua(unicode(url))
         self.info = self.lua.python2lua(reply2har(response))
-        status = response.attribute(QNetworkRequest.HttpStatusCodeAttribute)
-        self.status = self.lua.python2lua(status.toInt()[0])
         commands = get_commands(self)
         self.commands = self.lua.python2lua(commands)
         self.attr_whitelist = list(commands.keys()) + self._attribute_whitelist
         self._exceptions = []
-        # TODO add HTTP method to wrapped response (reply.operation() returns integer)
-        # and we probably prefer string not integer
 
     def clear(self):
         self.response = None

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -632,6 +632,8 @@ class Splash(object):
     def private_on_response_headers(self, callback):
 
         def res_callback(reply):
+            # TODO do we need request as another argument here?
+            # can it be useful to have request in Lua callback?
             with wrapped_response(self.lua, reply) as res:
                 callback(res)
 
@@ -693,6 +695,8 @@ def _requires_request(meth):
 
 class _WrappedRequest(object):
     """ QNetworkRequest wrapper for Lua """
+    # TODO perhaps refactor common parts
+    # of wrapped response and wrapped request into common object?
 
     _attribute_whitelist = ['info', 'commands']
 
@@ -736,15 +740,12 @@ class _WrappedRequest(object):
 @contextlib.contextmanager
 def wrapped_response(lua, reply):
     """
-    Context manager which returns a wrapped QNetworkRequest
+    Context manager which returns a wrapped QNetworkReply
     suitable for using in Lua code.
     """
     res = _WrappedResponse(lua, reply)
-    try:
-        with lua.object_allowed(res, res.attr_whitelist):
-            yield res
-    finally:
-        pass
+    with lua.object_allowed(res, res.attr_whitelist):
+        yield res
 
 
 class _WrappedResponse(object):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -748,11 +748,12 @@ def wrapped_response(lua, reply):
 
 
 class _WrappedResponse(object):
-    _attribute_whitelist = ['headers', 'commands', "response"]
+    _attribute_whitelist = ['commands', "response"]
 
     def __init__(self, lua, response):
         self.lua = lua
         self.response = response
+        self.headers = dict([(str(k), str(v)) for k, v in response.rawHeaderPairs()])
         commands = get_commands(self)
         self.commands = self.lua.python2lua(commands)
         self.attr_whitelist = list(commands.keys()) + self._attribute_whitelist
@@ -761,6 +762,10 @@ class _WrappedResponse(object):
     @command()
     def abort(self):
         self.response.abort()
+
+    @command()
+    def get_header(self, name):
+        return self.headers.get(name)
 
 
 class SplashScriptRunner(BaseScriptRunner):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -766,7 +766,7 @@ class _WrappedResponse(object):
     def __init__(self, lua, response):
         self.lua = lua
         self.response = response
-        self.headers = dict([(str(k), str(v)) for k, v in response.rawHeaderPairs()])
+        self.headers = {str(k): str(v) for k, v in response.rawHeaderPairs()}
         commands = get_commands(self)
         self.commands = self.lua.python2lua(commands)
         self.attr_whitelist = list(commands.keys()) + self._attribute_whitelist
@@ -783,8 +783,14 @@ class _WrappedResponse(object):
         self.response.abort()
 
     @command()
+    @_requires_response
     def get_header(self, name):
         return self.headers.get(name)
+
+    @command()
+    @_requires_response
+    def get_headers(self):
+        return self.headers
 
 
 class SplashScriptRunner(BaseScriptRunner):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -628,6 +628,12 @@ class Splash(object):
         self.tab.register_callback("on_request", py_callback)
         return True
 
+    @command(sets_callback=True)
+    def private_on_response_headers(self, callback):
+        py_callback = lambda a,b,c: ()
+        self.tab.register_callback("on_response_headers", py_callback)
+        return True
+
     def _error_info_to_lua(self, error_info):
         if error_info is None:
             return "error"

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -693,15 +693,6 @@ def _requires_request(meth):
     return wrapper
 
 
-def _requires_response(meth):
-    @functools.wraps(meth)
-    def wrapper(self, *args, **kwargs):
-        if self.response is None:
-            raise ValueError("response is used outside callback")
-        return meth(self, *args, **kwargs)
-    return wrapper
-
-
 class _WrappedRequest(object):
     """ QNetworkRequest wrapper for Lua """
     # TODO perhaps refactor common parts
@@ -744,6 +735,15 @@ class _WrappedRequest(object):
     @_requires_request
     def set_header(self, name, value):
         self.request.setRawHeader(name, value)
+
+
+def _requires_response(meth):
+    @functools.wraps(meth)
+    def wrapper(self, *args, **kwargs):
+        if self.response is None:
+            raise ValueError("response is used outside callback")
+        return meth(self, *args, **kwargs)
+    return wrapper
 
 
 @contextlib.contextmanager

--- a/splash/qwebpage.py
+++ b/splash/qwebpage.py
@@ -54,6 +54,7 @@ class SplashQWebPage(QWebPage):
         self.cookiejar = SplashCookieJar(self)
         self.callbacks = {
             'on_request': [],
+            "on_response_headers": []
         }
 
         self.mainFrame().urlChanged.connect(self.onUrlChanged)

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -598,11 +598,19 @@ class Subresources(Resource):
             request.setHeader("Content-Type", "text/css; charset=utf-8")
             print "Request Style!"
             return "body { background-color: red; }"
+
     class Image(Resource):
         def render_GET(self, request):
             request.setHeader("Content-Type", "image/gif")
             return base64.decodestring('R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=')
 
+
+class SetHeadersResource(Resource):
+    def render_GET(self, request):
+        for k, values in request.args.iteritems():
+            for v in values:
+                request.setHeader(k, v)
+        return ""
 
 class InvalidContentTypeResource(Resource):
     def render_GET(self, request):
@@ -677,6 +685,7 @@ class Root(Resource):
         self.putChild("very-long-green-page", VeryLongGreenPage())
         self.putChild("rgb-stripes", RgbStripesPage())
         self.putChild("subresources", Subresources())
+        self.putChild("set-header", SetHeadersResource())
 
         self.putChild("jsredirect", JsRedirect())
         self.putChild("jsredirect-to", JsRedirectTo())

--- a/splash/tests/test_execute_callbacks.py
+++ b/splash/tests/test_execute_callbacks.py
@@ -130,20 +130,15 @@ class OnRequestTest(BaseLuaRenderTest, BaseHtmlProxyTest):
 
 
 class OnResponseTest(BaseLuaRenderTest, BaseHtmlProxyTest):
-    def test_on_response_headers(self):
+    def test_abort_on_response_headers(self):
         resp = self.request_lua("""
         function main(splash)
-            splash:on_response_headers(function(response)
-                response:set_header("Server", "splash")
+            splash:on_response_headers(function(response, request)
+                request:abort()
             end)
-            res = splash:http_get("http://httpbin.org/headers")
+            res = splash:http_get(splash.args.url)
             return res
         end
-        """, {'url': self.mockurl("show-image")})
+        """, {'url': self.mockurl("jsrender")})
         self.assertStatusCode(resp, 200)
-        headers = resp.json().get("headers")
-        hs = {}
-        for h in headers:
-            hs[h["name"]] = h["value"]
-
-        # self.assertEqual(hs.get("Server"), "splash")
+        self.assertFalse(resp.json().get("content").get("text"))

--- a/splash/tests/test_execute_callbacks.py
+++ b/splash/tests/test_execute_callbacks.py
@@ -134,7 +134,7 @@ class OnResponseTest(BaseLuaRenderTest, BaseHtmlProxyTest):
         resp = self.request_lua("""
         function main(splash)
             splash:on_response_headers(function(response)
-                response.set_header("Server", "splash")
+                response:set_header("Server", "splash")
             end)
             res = splash:http_get("http://httpbin.org/headers")
             return res

--- a/splash/tests/test_execute_callbacks.py
+++ b/splash/tests/test_execute_callbacks.py
@@ -127,3 +127,23 @@ class OnRequestTest(BaseLuaRenderTest, BaseHtmlProxyTest):
 
         self.assertIn("'custom-header': 'some-val'", resp.text)
         self.assertIn("'user-agent': 'Fooozilla'", resp.text)
+
+
+class OnResponseTest(BaseLuaRenderTest, BaseHtmlProxyTest):
+    def test_on_response_headers(self):
+        resp = self.request_lua("""
+        function main(splash)
+            splash:on_response_headers(function(response)
+                response.set_header("Server", "splash")
+            end)
+            res = splash:http_get("http://httpbin.org/headers")
+            return res
+        end
+        """, {'url': self.mockurl("show-image")})
+        self.assertStatusCode(resp, 200)
+        headers = resp.json().get("headers")
+        hs = {}
+        for h in headers:
+            hs[h["name"]] = h["value"]
+
+        # self.assertEqual(hs.get("Server"), "splash")

--- a/splash/tests/test_execute_callbacks.py
+++ b/splash/tests/test_execute_callbacks.py
@@ -136,7 +136,7 @@ class OnResponseHeadersTest(BaseLuaRenderTest, BaseHtmlProxyTest):
         function main(splash)
             local header_value = nil
             splash:on_response_headers(function(response)
-                header_value = response:get_header('Content-Type')
+                header_value = response.headers['Content-Type']
             end)
             res = splash:http_get(splash.args.url)
             return header_value
@@ -150,7 +150,7 @@ class OnResponseHeadersTest(BaseLuaRenderTest, BaseHtmlProxyTest):
         resp = self.request_lua("""
         function main(splash)
             splash:on_response_headers(function(response)
-                if response:get_header('Content-Type') == 'text/html' then
+                if response.headers['Content-Type'] == 'text/html' then
                     response:abort()
                 end
             end)

--- a/splash/utils.py
+++ b/splash/utils.py
@@ -51,7 +51,7 @@ def get_alive():
         'QNetworkRequest', 'QNetworkReply', 'QNetworkProxy',
         'QSize', 'QBuffer', 'QPainter', 'QImage', 'QUrl', 'QTimer',
         'SplashCookieJar', 'OneShotCallbackProxy', '_WrappedRequest',
-        'BrowserTab', '_SplashHttpClient',
+        '_WrappedResponse', 'BrowserTab', '_SplashHttpClient',
         'JavascriptConsole', 'ProfilesSplashProxyFactory',
         'SplashProxyRequest', 'Request', 'Deferred',
         'LuaRuntime', '_LuaObject', '_LuaTable', '_LuaIter', '_LuaThread',


### PR DESCRIPTION
Adds support for Lua callback `on_response_headers`. Callback will accept response object as argument, for now this object will have two methods: `get_header` and `abort()`. Using callback will allow users to abort requests if some header is present in response (e.g. content_type). 

https://github.com/scrapinghub/splash/issues/231