### PR TITLE
request:set_timeout

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -49,6 +49,11 @@ timeout : float : optional
 
       $ python -m splash.server --max-timeout 120
 
+.. _arg-resource-timeout:
+
+resource_timeout : float : optional
+  A timeout (in seconds) for individual network requests.
+
 .. _arg-wait:
 
 wait : float : optional
@@ -798,6 +803,9 @@ X-Splash-js : string
 
 X-Splash-timeout : string
   Same as :ref:`'timeout' <arg-timeout>` argument for `render.html`_.
+
+X-Splash-resource-timeout : string
+  Same as :ref:`'wait' <arg-resource-timeout>` argument for `render.html`_.
 
 X-Splash-wait : string
   Same as :ref:`'wait' <arg-wait>` argument for `render.html`_.

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -1571,6 +1571,9 @@ one of the ``request`` methods:
   also work; it is implemented using CONNECT command.
 * ``request:set_header(name, value)`` - set an HTTP header for this request.
   See also: :ref:`splash-set-custom-headers`.
+* ``request:set_timeout(timeout)`` - set a timeout for this request,
+  in seconds. If response is not fully received after the timeout,
+  request is aborted.
 
 A callback passed to :ref:`splash-on-request` can't call Splash
 async methods like :ref:`splash-wait` or :ref:`splash-go`.
@@ -1635,6 +1638,15 @@ request to Splash:
             password = splash.args.password,
         }
     end)
+
+Example 6 - discard requests which take longer than 5 seconds to complete:
+
+.. code-block:: lua
+
+    splash:on_request(function(request)
+        request:set_timeout(5.0)
+    end)
+
 
 .. note::
 

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -162,6 +162,10 @@ class BrowserTab(QObject):
         """
         self.web_page.custom_headers = headers
 
+    def set_resource_timeout(self, timeout):
+        """ Set a default timeout for HTTP requests, in seconds. """
+        self.web_page.resource_timeout = timeout
+
     def set_images_enabled(self, enabled):
         self.web_page.settings().setAttribute(QWebSettings.AutoLoadImages,
                                               enabled)

--- a/splash/proxy_server.py
+++ b/splash/proxy_server.py
@@ -24,7 +24,7 @@ SPLASH_RESOURCES = {
 # Note the http header use '-' instead of '_' for the parameter names
 HTML_PARAMS = ['baseurl', 'timeout', 'wait', 'proxy', 'allowed-domains',
                'viewport', 'js', 'js-source', 'images', 'filters',
-               'render-all', 'scale-method']
+               'render-all', 'scale-method', 'resource-timeout']
 PNG_PARAMS = ['width', 'height']
 JPEG_PARAMS = ['width', 'height', 'quality']
 JSON_PARAMS = ['html', 'png', 'jpeg', 'iframes', 'script', 'console', 'history', 'har']

--- a/splash/qtrender.py
+++ b/splash/qtrender.py
@@ -80,7 +80,7 @@ class DefaultRenderScript(RenderScript):
     def start(self, url, baseurl=None, wait=None, viewport=None,
               js_source=None, js_profile=None, images=None, console=False,
               headers=None, http_method='GET', body=None,
-              render_all=False):
+              render_all=False, resource_timeout=None):
 
         self.url = url
         self.wait_time = defaults.WAIT_TIME if wait is None else wait
@@ -89,6 +89,9 @@ class DefaultRenderScript(RenderScript):
         self.console = console
         self.viewport = defaults.VIEWPORT_SIZE if viewport is None else viewport
         self.render_all = render_all or viewport == 'full'
+
+        if resource_timeout:
+            self.tab.set_resource_timeout(resource_timeout)
 
         if images is not None:
             self.tab.set_images_enabled(images)

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -748,6 +748,11 @@ class _WrappedRequest(object):
     def set_header(self, name, value):
         self.request.setRawHeader(name, value)
 
+    @command()
+    @_requires_request
+    def set_timeout(self, timeout):
+        self.request.timeout = float(timeout)
+
 
 def _requires_response(meth):
     @functools.wraps(meth)

--- a/splash/qtutils.py
+++ b/splash/qtutils.py
@@ -13,7 +13,7 @@ from PyQt4.QtCore import (QAbstractEventDispatcher, QDateTime, QObject,
                           QRegExp, QString, QUrl, QVariant)
 from PyQt4.QtGui import QApplication
 from PyQt4.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkProxy
-from PyQt4.QtWebKit import QWebSettings
+from PyQt4.QtWebKit import QWebSettings, QWebFrame
 from twisted.python import log
 
 from splash.utils import truncated
@@ -251,3 +251,11 @@ class WrappedSignal(object):
 
 def clear_caches():
     QWebSettings.clearMemoryCaches()
+
+
+def get_request_webframe(request):
+    """ Return a QWebFrame which sent this QNetworkRequest """
+    web_frame = request.originatingObject()
+    if isinstance(web_frame, QWebFrame):
+        return web_frame
+    return None

--- a/splash/qwebpage.py
+++ b/splash/qwebpage.py
@@ -46,6 +46,7 @@ class SplashQWebPage(QWebPage):
     custom_headers = None
     skip_custom_headers = False
     navigation_locked = False
+    resource_timeout = 0
 
     def __init__(self, verbosity=0):
         super(QWebPage, self).__init__()

--- a/splash/render_options.py
+++ b/splash/render_options.py
@@ -106,6 +106,9 @@ class RenderOptions(object):
         default = min(self.max_timeout, defaults.TIMEOUT)
         return self.get("timeout", default, type=float, range=(0, self.max_timeout))
 
+    def get_resource_timeout(self):
+        return self.get("resource_timeout", 0, type=float, range=(0, 1e6))
+
     def get_images(self):
         return self._get_bool("images", defaults.AUTOLOAD_IMAGES)
 
@@ -239,6 +242,7 @@ class RenderOptions(object):
             'url': self.get_url(),
             'baseurl': self.get_baseurl(),
             'wait': wait,
+            'resource_timeout': self.get_resource_timeout(),
             'viewport': self.get_viewport(wait),
             'render_all': self.get_render_all(wait),
             'images': self.get_images(),

--- a/splash/request_middleware.py
+++ b/splash/request_middleware.py
@@ -9,7 +9,7 @@ import re
 import os
 import urlparse
 from twisted.python import log
-from splash.qtutils import request_repr, drop_request
+from splash.qtutils import request_repr, drop_request, get_request_webframe
 
 
 class AllowedDomainsMiddleware(object):
@@ -61,6 +61,7 @@ class AllowedSchemesMiddleware(object):
             drop_request(request)
         return request
 
+
 class RequestLoggingMiddleware(object):
     """ Request middleware for logging requests """
     def process(self, request, render_options, operation, data):
@@ -68,6 +69,19 @@ class RequestLoggingMiddleware(object):
             "[%s] %s" % (render_options.get_uid(), request_repr(request, operation)),
             system='network'
         )
+        return request
+
+
+class ResourceTimeoutMiddleware(object):
+    """
+    Request middleware which sets timeouts for requests based on
+    ``resource_timeout`` attribute of QWebPage.
+    """
+    def process(self, request, render_options, operation, data):
+        web_frame = get_request_webframe(request)
+        if not web_frame:
+            return request
+        request.timeout = getattr(web_frame.page(), 'resource_timeout', 0)
         return request
 
 

--- a/splash/tests/lua_modules/emulation.lua
+++ b/splash/tests/lua_modules/emulation.lua
@@ -37,6 +37,13 @@ function Splash:go_and_wait(args)
     self:set_viewport_size(tonumber(w), tonumber(h))
   end
 
+  -- set a resource timeout
+  if args.resource_timeout ~= nil then
+    self:on_request(function(request)
+      request:set_timeout(args.resource_timeout)
+    end)
+  end
+
   local ok, reason = self:go{url=url, baseurl=args.baseurl}
   if not ok then
     -- render.xxx endpoints don't return HTTP errors as errors,

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -241,10 +241,11 @@ class ShowImage(Resource):
 
     def render_GET(self, request):
         token = random.random()  # prevent caching
+        n = getarg(request, "n", 0, type=float)
         return """<html><body>
-        <img id='foo' width=50 heigth=50 src="/slow.gif?n=0&rnd=%s">
+        <img id='foo' width=50 heigth=50 src="/slow.gif?n=%s&rnd=%s">
         </body></html>
-        """ % token
+        """ % (n, token)
 
 
 class IframeResource(Resource):

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -198,6 +198,14 @@ class Base(object):
                                   'wait': wait})
                 self.assertStatusCode(r, 400)
 
+        def test_resource_timeout(self):
+            resp = self.request({
+                'url': self.mockurl("show-image?n=10"),
+                'timeout': "3",
+                'resource_timeout': "0.5",
+            })
+            self.assertStatusCode(resp, 200)
+
 
 class RenderHtmlTest(Base.RenderTest):
 


### PR DESCRIPTION
This method allows individual outgoing requests to be aborted after a timeout.
It allows to prevent long requests from making the whole script timeout.

TODO:

* [x] tests
* [x] `resource_timeout` argument for render.xxx endpoints