### PR TITLE
[WIP] Use psutil to check memory

### DIFF
--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -627,6 +627,7 @@ class Splash(object):
         rusage = resource.getrusage(resource.RUSAGE_SELF)
         # on Mac OS X ru_maxrss is in bytes, on Linux it is in KB
         rss_mul = 1 if sys.platform == 'darwin' else 1024
+        # TODO: add splash.utils.get_memory_usage here?
         return {'maxrss': rusage.ru_maxrss * rss_mul,
                 'cputime': rusage.ru_utime + rusage.ru_stime,
                 'walltime': time.time()}

--- a/splash/resources.py
+++ b/splash/resources.py
@@ -128,6 +128,7 @@ class BaseRenderResource(_ValidatingResource):
             "path": request.path,
             "args": request.args,
             "rendertime": time.time() - request.starttime,
+            # TODO: add splash.utils.get_memory_usage here?
             "maxrss": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
             "load": os.getloadavg(),
             "fds": get_num_fds(),

--- a/splash/utils.py
+++ b/splash/utils.py
@@ -1,17 +1,17 @@
 from __future__ import absolute_import
-
-import os
-import gc
-import sys
-import json
 import base64
+import gc
 import inspect
-import resource
+import json
+import os
 from collections import defaultdict
+
 import psutil
 
 
 _REQUIRED = object()
+PID = os.getpid()
+PSUTIL_PROCESS = psutil.Process()
 
 
 class BadRequest(Exception):
@@ -35,7 +35,6 @@ class SplashJSONEncoder(json.JSONEncoder):
         return super(SplashJSONEncoder, self).default(o)
 
 
-PID = os.getpid()
 def get_num_fds():
     proc = psutil.Process(PID)
     try:
@@ -72,13 +71,8 @@ def get_leaks():
     return get_alive()
 
 
-def get_ru_maxrss():
-    """ Return max RSS usage (in bytes) """
-    size = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-    if sys.platform != 'darwin':
-        # on Mac OS X ru_maxrss is in bytes, on Linux it is in KB
-        size *= 1024
-    return size
+def get_memory_usage():
+    return PSUTIL_PROCESS.memory_info().rss
 
 
 def get_total_phymem():


### PR DESCRIPTION
Splash uses `resource.getrusage(resource.RUSAGE_SELF).ru_maxrss` which have several downsides and I believe is not very suitable for this task:

1. This was discussed in https://github.com/scrapy/scrapy/pull/1329. @dangra [said](https://github.com/scrapy/scrapy/pull/1329#issue-92307403):

```
This is particulary problematic when running spiders inside docker containers because docker daemon can take up to GBs of RAM and its max_rss is propagated to init process of the docker container.
```

Looks like it can be an issue for Splash instance as well

2. Splash itself is a kind of application which allow peaks of memory usage, but after that peak memory usage goes down usually, but `max_rss` never goes down, so Splash instance will be shut down after one such memory usage peak despite current memory usage might be really low - which leads to server restart, makes service unavailable, clears all cache and forces all pages to be downloaded once again which is bad in terms of performance.

An article about difference between `max_rss` and `psutils` can be found [here](http://fa.bianp.net/blog/2013/different-ways-to-get-memory-consumption-or-lessons-learned-from-memory_profiler/)

Splash already depends on `psutil`, so it's not a problem to use it for a memory check. 

First commit is intended to start discussion, it's not the code I want to merge right away. First of all because this change is to some extent backwards incompatible, and probably we can have another Splash option to enable `psutil` memory check and keep `maxrss` option for compatibility, maybe remove it later. But there's one more thing about how `psutil` measures memory. In general it would allow spikes of memory usage and would work okay, util memory check will be launched during some memory intensive process. In this case `psutil` behaviour would be the same as `max_rss`, but this PR rather aims to find better solution for memory check than simply replace `max_rss` with `psutil`. So instead of simply measuring memory usage with `psutil` I wanted to propose using moving average as a metric for memory measurement. We can collect 3-5 points of memory usage and compare to the limit. This will allow to remove some random fluctuations and shut down instance only in case when memory usage in average is higher than some give watermark. 