### PR TITLE
pytest.skip doesn't do what we want.

### DIFF
--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -198,7 +198,7 @@ class Base(object):
                                   'wait': wait})
                 self.assertStatusCode(r, 400)
 
-        @pytest.skip("resource_timeout doesn't work in Qt5. See issue #269 for details.")
+        @pytest.mark.skipif(True, reason="resource_timeout doesn't work in Qt5. See issue #269 for details.")
         def test_resource_timeout(self):
             resp = self.request({
                 'url': self.mockurl("show-image?n=10"),


### PR DESCRIPTION
Hey @kmike,
#272 actually doesn't do what I expected. `pytest.skip` actually skips all the tests in the file. It's an issue in pytest https://github.com/pytest-dev/pytest/issues/607. I managed to missed that somehow. 