### PR TITLE
Disable localStorage

### DIFF
--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -118,7 +118,7 @@ class BrowserTab(QObject):
         settings.setAttribute(QWebSettings.JavascriptEnabled, True)
         settings.setAttribute(QWebSettings.PluginsEnabled, False)
         settings.setAttribute(QWebSettings.PrivateBrowsingEnabled, True)
-        settings.setAttribute(QWebSettings.LocalStorageEnabled, True)
+        settings.setAttribute(QWebSettings.LocalStorageEnabled, False)
         settings.setAttribute(QWebSettings.LocalContentCanAccessRemoteUrls, True)
 
         scroll_bars = Qt.ScrollBarAsNeeded if self.visible else Qt.ScrollBarAlwaysOff


### PR DESCRIPTION
A lot of websites use localStorage like this:

```
if(window.localStorage) {
    localStorage.completely_useless_persistent_information = '...'
} else {
    // Use alternative storage method (cookies, server side) or don't
    // store data at all
}
loadTheRestOfTheApplication();
```
At the moment in splash localStorage exists and is an object but trying
to set a property will raise an exception and prevent the application to
load. This disables localStorage (window.localStorage is null) and will
make code like the above work