### PR TITLE
Add support for specifying the proxy URL directly.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -71,7 +71,13 @@ wait : float : optional
 .. _arg-proxy:
 
 proxy : string : optional
-  Proxy profile name. See :ref:`Proxy Profiles`.
+  Proxy profile name or proxy URL. See :ref:`Proxy Profiles`.
+
+  A proxy URL should have the following format:
+  ``[protocol://][user:password@]proxyhost[:port])``
+
+  Where protocol is either ``http`` or ``socks5``. If port is not specified,
+  the port 1080 is used by default.
 
 .. _arg-js:
 

--- a/splash/proxy.py
+++ b/splash/proxy.py
@@ -11,6 +11,7 @@ an HTTP proxy (see :mod:`splash.proxy_server`).
 from __future__ import absolute_import
 import re
 import os
+import urlparse
 import ConfigParser
 
 from PyQt4.QtNetwork import QNetworkProxy
@@ -158,6 +159,49 @@ class ProfilesSplashProxyFactory(_BlackWhiteSplashProxyFactory):
                        proxy.get('username'), proxy.get('password'),
                        proxy.get('type'))]
         return blacklist, whitelist, proxy_list
+
+
+class DirectSplashProxyFactory(object):
+    """
+    This proxy factory will set the proxy passed to a render request
+    using a parameter.
+
+    If GET parameter is a fully qualified URL, use the specified proxy.
+    The syntax to specify the proxy is:
+    [protocol://][user:password@]proxyhost[:port])
+
+    Where protocol is either ``http`` or ``socks5``. If port is not specified,
+    it's assumed to be 1080.
+    """
+    def __init__(self, proxy):
+        url = urlparse.urlparse(proxy)
+        if url.scheme and url.scheme in ('http', 'socks5') and url.hostname:
+            self.proxy = create_proxy(
+                url.hostname,
+                url.port or 1080,
+                username=url.username,
+                password=url.password,
+                type=url.scheme.upper()
+            )
+        else:
+            raise BadOption('Invalid proxy URL format.')
+
+    def queryProxy(self, *args, **kwargs):
+        return [self.proxy]
+
+
+def getFactory(ini_path, parameter):
+    """
+    Returns the appropriate factory depending on the value of
+    ini_path and parameter
+    """
+    if parameter and re.match('^\w+://', parameter):
+        return DirectSplashProxyFactory(parameter)
+    else:
+        if ini_path:
+            return ProfilesSplashProxyFactory(ini_path, parameter)
+        else:
+            return None
 
 
 def _get_lines(config_parser, section, option, default):

--- a/splash/server.py
+++ b/splash/server.py
@@ -300,16 +300,16 @@ def _default_proxy_factory(proxy_profiles_path):
     from twisted.python import log
     from splash import proxy
 
-    if proxy_profiles_path is not None and not os.path.isdir(proxy_profiles_path):
-        log.msg("--proxy-profiles-path does not exist or it is not a folder; "
-                "proxy won't be used")
-        proxy_profiles_enabled = False
-    else:
-        proxy_profiles_enabled = proxy_profiles_path is not None
+    if proxy_profiles_path is not None:
+        if os.path.isdir(proxy_profiles_path):
+            log.msg("proxy profiles support is enabled, "
+                    "proxy profiles path: %s" % proxy_profiles_path)
+        else:
+            log.msg("--proxy-profiles-path does not exist or it is not a folder; "
+                    "proxy won't be used")
+            proxy_profiles_path = None
 
-    if proxy_profiles_enabled:
-        log.msg("proxy profiles support is enabled, proxy profiles path: %s" % proxy_profiles_path)
-        return functools.partial(proxy.ProfilesSplashProxyFactory, proxy_profiles_path)
+    return functools.partial(proxy.getFactory, proxy_profiles_path)
 
 
 def _check_js_profiles_path(js_profiles_path):


### PR DESCRIPTION
Yes, I saw the other PR.

This allows passing either an URL or a profile name as the proxy parameter

Fixes  #160