### PR TITLE
Fix double-encoding of URL Paths

### DIFF
--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -7,7 +7,7 @@ import os
 import weakref
 import uuid
 
-from PyQt4.QtCore import QObject, QSize, Qt, QTimer, QUrl, pyqtSlot
+from PyQt4.QtCore import QObject, QSize, Qt, QTimer, pyqtSlot
 from PyQt4.QtNetwork import QNetworkRequest
 from PyQt4.QtWebKit import QWebPage, QWebSettings
 from twisted.internet import defer
@@ -16,7 +16,7 @@ from twisted.python import log
 from splash import defaults
 from splash.har.qt import cookies2har
 from splash.qtrender_image import QtImageRenderer
-from splash.qtutils import OPERATION_QT_CONSTANTS, WrappedSignal, qt2py, qurl2ascii
+from splash.qtutils import OPERATION_QT_CONSTANTS, WrappedSignal, qt2py, qurl2ascii, to_qurl
 from splash.render_options import validate_size_str
 from splash.qwebpage import SplashQWebPage, SplashQWebView
 from splash.exceptions import JsError, OneShotCallbackError
@@ -232,7 +232,7 @@ class BrowserTab(QObject):
             errback=errback,
         )
         self.logger.log("callback %s is connected to loadFinished" % callback_id, min_level=3)
-        self.web_page.mainFrame().setContent(data, mime_type, QUrl(baseurl))
+        self.web_page.mainFrame().setContent(data, mime_type, to_qurl(baseurl))
 
     def set_user_agent(self, value):
         """ Set User-Agent header for future requests """
@@ -814,7 +814,7 @@ class _SplashHttpClient(QObject):
     def request_obj(self, url, headers=None, body=None):
         """ Return a QNetworkRequest object """
         request = QNetworkRequest()
-        request.setUrl(QUrl(url))
+        request.setUrl(to_qurl(url))
         request.setOriginatingObject(self.web_page.mainFrame())
 
         if headers is not None:

--- a/splash/cookies.py
+++ b/splash/cookies.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from PyQt4.QtCore import QDateTime, Qt, QUrl
+from PyQt4.QtCore import QDateTime, Qt
 from PyQt4.QtNetwork import QNetworkRequest, QNetworkCookie, QNetworkCookieJar
+
+from splash.qtutils import to_qurl
 
 
 class SplashCookieJar(QNetworkCookieJar):
@@ -36,7 +38,7 @@ class SplashCookieJar(QNetworkCookieJar):
         if url is None:
             new_cookies = [c for c in all_cookies if bytes(c.name()) != name]
         else:
-            remove_cookies = self.cookiesForUrl(QUrl(url))
+            remove_cookies = self.cookiesForUrl(to_qurl(url))
             if name is not None:
                 remove_cookies = [c for c in remove_cookies if bytes(c.name()) == name]
             to_remove = {self._cookie_fp(c) for c in remove_cookies}

--- a/splash/qtutils.py
+++ b/splash/qtutils.py
@@ -8,7 +8,6 @@ import itertools
 import sys
 import time
 
-
 from PyQt4.QtCore import (QAbstractEventDispatcher, QDateTime, QObject,
                           QRegExp, QString, QUrl, QVariant)
 from PyQt4.QtGui import QApplication
@@ -141,9 +140,19 @@ def qurl2ascii(url):
     return url
 
 
+def to_qurl(s):
+    if isinstance(s, QUrl):
+        return s
+
+    if isinstance(s, unicode):
+        s = s.encode('utf-8')
+
+    return QUrl.fromEncoded(s)
+
+
 def set_request_url(request, url):
     """ Set an URL for a QNetworkRequest """
-    request.setUrl(QUrl(url))
+    request.setUrl(to_qurl(url))
 
 
 def drop_request(request):

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -433,6 +433,14 @@ class GetResource(Resource):
 """ % (headers, payload)
 
 
+class EchoUrl(Resource):
+    def render_GET(self, request):
+        return request.uri
+
+    def getChild(self, name, request):
+        return self
+
+
 JsPostResource = _html_resource("""
 <html>
 <body>
@@ -783,6 +791,7 @@ class Root(Resource):
         self.putChild("rgb-stripes", RgbStripesPage())
         self.putChild("subresources", Subresources())
         self.putChild("set-header", SetHeadersResource())
+        self.putChild("echourl", EchoUrl())
 
         self.putChild("jsredirect", JsRedirect())
         self.putChild("jsredirect-to", JsRedirectTo())

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -282,6 +282,13 @@ class RenderHtmlTest(Base.RenderTest):
             r.text
         )
 
+    def test_path_encoding(self):
+        r = self.request({'url': self.mockurl(u'echourl/例/')})
+        self.assertTrue('/echourl/%E4%BE%8B' in r.text)
+
+        r = self.request({'url': self.mockurl(u'echourl/%E4%BE%8B/')})
+        self.assertTrue('/echourl/%E4%BE%8B' in r.text)
+
     def test_result_encoding(self):
         r1 = requests.get(self.mockurl('cp1251'))
         self.assertStatusCode(r1, 200)


### PR DESCRIPTION
This is a bug only present on the qt4 version, this change tries to
emulate what seems to be the default behaviour in qt5.