### PR TITLE
JS cookie support ( #238, #135)

### DIFF
--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -195,11 +195,12 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
             request.setRawHeader(name, value)
 
     def _handle_request_cookies(self, request):
-        jar = QNetworkCookieJar()
-        self.setCookieJar(jar)
         cookiejar = self._get_webpage_attribute(request, "cookiejar")
         if cookiejar is not None:
             cookiejar.update_cookie_header(request)
+            self.setCookieJar(cookiejar)
+        else:
+            self.setCookieJar(QNetworkCookieJar())
 
     def _handle_reply_cookies(self, reply):
         cookiejar = self._get_webpage_attribute(reply.request(), "cookiejar")

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -1791,7 +1791,7 @@ class SetUserAgentTest(BaseLuaRenderTest):
 
 
 class CookiesTest(BaseLuaRenderTest):
-    def test_cookies(self):
+    def test_cookies(self, use_js=''):
         resp = self.request_lua("""
         function main(splash)
             local function cookies_after(url)
@@ -1824,8 +1824,8 @@ class CookiesTest(BaseLuaRenderTest):
             return {c0=c0, c1=c1, c2=c2, c3=c3, c4=c4, c5=c5, c6=c6, c7=c7, c8=c8, c9=c9}
         end
         """, {
-            "url_1": self.mockurl("set-cookie?key=foo&value=bar"),
-            "url_2": self.mockurl("set-cookie?key=egg&value=spam"),
+            "url_1": self.mockurl("set-cookie?key=foo&value=bar&use_js=%s" % use_js),
+            "url_2": self.mockurl("set-cookie?key=egg&value=spam&use_js=%s" % use_js),
         })
 
         self.assertStatusCode(resp, 200)
@@ -1858,6 +1858,9 @@ class CookiesTest(BaseLuaRenderTest):
         self.assertEqual(data["c7"], [cookie2])
         self.assertEqual(data["c8"], [])
         self.assertEqual(data["c9"], data["c2"])
+
+    def test_cookies_js(self):
+        self.test_cookies('true')
 
     def test_add_cookie(self):
         resp = self.request_lua("""

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -317,21 +317,29 @@ class RenderHtmlTest(Base.RenderTest):
         self.assertResponse200Get(503)
 
     def test_cookies_perserved_after_js_redirect(self):
-        get_cookie_url = self.mockurl("get-cookie?key=foo")
-        q = urllib.urlencode({"key": "foo", "value": "bar", "next": get_cookie_url})
-        url = self.mockurl("set-cookie?%s" % q)
-        resp = self.request({"url": url, "wait": 0.2})
-        self.assertStatusCode(resp, 200)
-        self.assertIn("bar", resp.text)
+        for use_js in "true", "":
+            get_cookie_url = self.mockurl("get-cookie?key=foo")
+            q = urllib.urlencode({
+                "key": "foo",
+                "value": "bar",
+                "next": get_cookie_url,
+                "use_js": use_js,
+            })
+            url = self.mockurl("set-cookie?%s" % q)
+            resp = self.request({"url": url, "wait": 0.2})
+            self.assertStatusCode(resp, 200)
+            self.assertIn("bar", resp.text)
 
     def test_cookies_are_not_shared(self):
-        resp = self.request({"url": self.mockurl("set-cookie?key=egg&value=spam")})
-        self.assertStatusCode(resp, 200)
-        self.assertIn("ok", resp.text)
+        for use_js in "true", "":
+            url = self.mockurl("set-cookie?key=egg&value=spam&use_js=%s" % use_js)
+            resp = self.request({"url": url})
+            self.assertStatusCode(resp, 200)
+            self.assertIn("ok", resp.text)
 
-        resp2 = self.request({"url": self.mockurl("get-cookie?key=egg")})
-        self.assertStatusCode(resp2, 200)
-        self.assertNotIn("spam", resp2.text)
+            resp2 = self.request({"url": self.mockurl("get-cookie?key=egg")})
+            self.assertStatusCode(resp2, 200)
+            self.assertNotIn("spam", resp2.text)
 
     def assertResponse200Get(self, code):
         url = self.mockurl('getrequest') + '?code=%d' % code


### PR DESCRIPTION
JS cookies are sent in the http headers, and header cookies are visible
to JavaScript.

This doesn't fix the cookie sharing problem between different sessions.