### PR TITLE
Private mode

### DIFF
--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -35,6 +35,19 @@ Enable or disable execution of JavaSript code embedded in the page.
 
 JavaScript execution is enabled by default.
 
+.. _splash-private-mode-enabled:
+
+splash.private_mode_enabled
+---------------------------
+
+Enable or disable browser's private mode (incognito mode).
+
+**Signature:** ``splash.private_mode_enabled = true/false``
+
+Private mode is enabled by default unless you pass flag ``--disable-private-mode`` at Splash startup.
+Note that if you disable private mode browsing data such as cookies or items kept in local 
+storage may persist between requests.
+
 .. _splash-resource-timeout:
 
 splash.resource_timeout

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -103,6 +103,15 @@ class BrowserTab(QObject):
         settings = self.web_page.settings()
         return settings.testAttribute(QWebSettings.JavascriptEnabled)
 
+    def set_private_mode_enabled(self, val):
+        settings = self.web_page.settings()
+        settings.setAttribute(QWebSettings.PrivateBrowsingEnabled, bool(val))
+        settings.setAttribute(QWebSettings.LocalStorageEnabled, not bool(val))
+
+    def get_private_mode_enabled(self):
+        settings = self.web_page.settings()
+        return settings.testAttribute(QWebSettings.PrivateBrowsingEnabled)
+
     def _set_default_webpage_options(self, web_page):
         """
         Set QWebPage options.

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -468,6 +468,16 @@ class Splash(BaseExposedObject):
     def set_js_enabled(self, value):
         self.tab.set_js_enabled(value)
 
+    @lua_property("private_mode_enabled")
+    @command()
+    def get_private_mode_enabled(self):
+        return self.tab.get_private_mode_enabled()
+
+    @get_private_mode_enabled.lua_setter
+    @command()
+    def set_private_mode_enabled(self, value):
+        self.tab.set_private_mode_enabled(bool(value))
+
     @command(async=True)
     def wait(self, time, cancel_on_redirect=False, cancel_on_error=True):
         time = float(time)


### PR DESCRIPTION
Allow users to enable/disable private_mode from Lua Scripts with a call to 

```lua
splash.private_mode_enabled = false/true -- similar to splash.js_enabled
```