### PR TITLE
Make strings explicitly unicode

### DIFF
--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -578,7 +578,7 @@ class BrowserTab(QObject):
         contains objects/arrays/primitives without circular references.
         """
         frame = self.web_page.mainFrame()
-        eval_expr = "eval({})".format(escape_js(js_source))
+        eval_expr = u"eval({})".format(escape_js(js_source))
 
         if result_protection:
             eval_expr = get_sanitized_result_js(eval_expr)
@@ -639,7 +639,7 @@ class BrowserTab(QObject):
         self._callback_proxies_to_cancel.add(callback_proxy)
         frame.addToJavaScriptWindowObject(callback_proxy.name, callback_proxy)
 
-        wrapped = """
+        wrapped = u"""
         (function () {
             try {
                 eval(%(script_text)s);

--- a/splash/jsutils.py
+++ b/splash/jsutils.py
@@ -9,7 +9,7 @@ def escape_js(*args):
 # with a restriction on maximum allowed depth.
 # A more natural way would be to use JSON.stringify,
 # but user can override global JSON object to bypass protection.
-SANITIZE_FUNC_JS = """
+SANITIZE_FUNC_JS = u"""
 function (obj, max_depth){
     max_depth = max_depth ? max_depth : 100;
     function _s(o, d) {
@@ -69,7 +69,7 @@ def get_sanitized_result_js(expression, max_depth=0):
     QWebFrame.evaluateJavaScript - Qt5 can go mad if we try to return something
     else (objects with circular references, DOM elements, ...).
     """
-    return "({sanitize_func})({expression}, {max_depth})".format(
+    return u"({sanitize_func})({expression}, {max_depth})".format(
         sanitize_func=SANITIZE_FUNC_JS,
         expression=expression,
         max_depth=max_depth
@@ -83,7 +83,7 @@ def get_process_errors_js(expression):
     or ``{error: true, errorType: ..., errorMessage: ..., errorRepr: ...}``
     if expression raised an error when evaluating.
     """
-    return """
+    return u"""
     (function() {
         try{
             return {


### PR DESCRIPTION
Several Travis python2 test were failing (https://travis-ci.org/scrapinghub/splash/jobs/103174284#L1967) and if using splash with python2 you would get UnicodeDecodeErrors when trying to run JavaScript with Unicode characters.