### PR TITLE
[browser_tab] delete NAT after using it

### DIFF
--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -364,6 +364,7 @@ class BrowserTab(QObject):
         self.web_view.close()
         self.web_page.deleteLater()
         self.web_view.deleteLater()
+        self.network_manager.deleteLater()
         self._cancel_all_timers()
 
     def _on_before_close(self):


### PR DESCRIPTION
It looks like requests can be downloaded by NAT even after render is done and finished. In #387 splash logs show that NAT downloads requests even after rendering is done and browser tab is deleted. If deleteLater() is not called it seems like render is done, but NAT is still in memory and is still in use, when executing callbacks it probably tries to access something that was deleted and it ends SEGFAULT. In practice this looks like this

```
2016-02-26 14:46:20.625144 [pool] [140615354659784] SLOT 1 is closing <splash.qtrender.PngRender object at 0x7fe39042fba8>
2016-02-26 14:46:20.625221 [render] [140615354659784] close is requested by a script
2016-02-26 14:46:20.625368 [render] [140615354659784] cancelling 0 remaining timers
2016-02-26 14:46:20.625444 [pool] [140615354659784] SLOT 1 done with <splash.qtrender.PngRender object at 0x7fe39042fba8>
2016-02-26 14:46:20.625859 [events] {"user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.109 Safari/537.36", "status_code": 200, "fds": 37, "timestamp": 1456494380, "path": "/render.png", "_id": 140615354659784, "load": [1.39, 1.42, 1.35], "method": "GET", "maxrss": 213004, "args": {"uid": 140615354659784, "images": "0", "url": "http://24ur.com/"}, "qsize": 0, "rendertime": 1.1569948196411133, "active": 0, "client_ip": "127.0.0.1"}
2016-02-26 14:46:20.625989 [-] "127.0.0.1" - - [26/Feb/2016:13:46:20 +0000] "GET /render.png?url=http://24ur.com/&images=0 HTTP/1.1" 200 78441 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.109 Safari/537.36"
2016-02-26 14:46:20.626146 [pool] SLOT 1 is available
2016-02-26 14:46:20.636429 [render] [140615354659784] loadStarted
2016-02-26 14:46:20.636701 [network] [140615354659784] GET http://www.24ur.com/adserver/adjs_i.php?n=181&zoneid=181&bannerid=0&target=_blank&exclude=,&r=201602261445&ct0=undefined&banner_location=VSTOPNI_1
2016-02-26 14:46:20.637942 [network] [140615354659784] GET http://www.24ur.com/adserver/adjs_i.php?n=182&zoneid=182&bannerid=0&target=_blank&exclude=,&r=201602261445&ct0=undefined&banner_location=VSTOPNI_2
2016-02-26 14:46:20.638952 [network] [140615354659784] GET http://www.24ur.com/adserver/adjs_i.php?n=183&zoneid=183&bannerid=0&target=_blank&exclude=,&r=201602261445&ct0=undefined&banner_location=VSTOPNI_3
2016-02-26 14:46:20.640036 [network] [140615354659784] GET http://www.24ur.com/adserver/adjs_i.php?n=184&zoneid=184&bannerid=0&target=_blank&exclude=,&r=201602261445&ct0=undefined&banner_location=VSTOPNI_4
2016-02-26 14:46:20.641323 [network] [140615354659784] GET http://www.24ur.com/bin/ajax/joke_get_vote.php?joke_id=816
2016-02-26 14:46:20.642492 [network] [140615354659784] GET http://www.24ur.com/adserver/adjs_i.php?n=185&zoneid=185&bannerid=0&target=_blank&exclude=,&r=201602261445&ct0=undefined&banner_location=VSTOPNI_5
2016-02-26 14:46:20.918787 [network-manager] Downloaded 0/0 of http://www.24ur.com/adserver/adjs_i.php?n=185&zoneid=185&bannerid=0&target=_blank&exclude=,&r=201602261445&ct0=undefined&banner_location=VSTOPNI_5
2016-02-26 14:46:20.919030 [network-manager] Finished downloading http://www.24ur.com/adserver/adjs_i.php?n=185&zoneid=185&bannerid=0&target=_blank&exclude=,&r=201602261445&ct0=undefined&banner_location=VSTOPNI_5
````
this is all part of one request to http://localhost:8050/render.png?url=http://24ur.com/&images=0 notice loadStarted event firing and requests being downloaded after SLOT is done and response theoretically returned to user.

After this commit it can still happen that NAT downloads resources after render is done, I didnt find any way to stop this behavior (we'd have to somehow cancel pending requests which seems difficult), but at least there is no SEGFAULTS. We could do more research into this if possible and if we think that downloading requests after rendering is some form of anomaly.

This fixes #387 