### PR TITLE
Implement render region param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
 
 script:
     - py.test --version
-    - py.test --cov=splash --doctest-modules -n $SPLASH_BUILD_PARALLEL_JOBS --duration=50 splash
+    - py.test --cov=splash --doctest-modules --duration=50 splash
 
 after_success:
     - codecov

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -1009,7 +1009,7 @@ splash:png
 
 Return a `width x height` screenshot of a current page in PNG format.
 
-**Signature:** ``png = splash:png{width=nil, height=nil, render_all=false, scale_method='raster'}``
+**Signature:** ``png = splash:png{width=nil, height=nil, render_all=false, scale_method='raster', region=nil}``
 
 **Parameters:**
 
@@ -1017,7 +1017,9 @@ Return a `width x height` screenshot of a current page in PNG format.
 * height - optional, height of a screenshot in pixels;
 * render_all - optional, if ``true`` render the whole webpage;
 * scale_method - optional, method to use when resizing the image, ``'raster'``
-  or ``'vector'``
+  or ``'vector'``;
+* region - optional, ``{left, top, right, bottom}`` coordinates of
+  a cropping rectangle.
 
 **Returns:** PNG screenshot data, as a :ref:`binary object <binary-objects>`.
 When the result is empty ``nil`` is returned.
@@ -1041,6 +1043,21 @@ To set the viewport size use :ref:`splash-set-viewport-size`,
 :ref:`splash-set-viewport-full` or *render_all* argument.  ``render_all=true``
 is equivalent to running ``splash:set_viewport_full()`` just before the
 rendering and restoring the viewport size afterwards.
+
+To render an arbitrary part of a page use *region* parameter. It should
+be a table with ``{left, top, right, bottom}`` coordinates. Coordinates
+are relative to current scroll position. Currently you can't take anything
+which is not in a viewport; to make sure part of a page can be rendered call
+:ref:`splash-set-viewport-full` before using :ref:`splash-png` with *region*.
+This may be fixed in future Splash versions.
+
+.. _example-render-element:
+
+With ``region`` and a bit of JavaScript it is possible to render only a single
+HTML element. Example:
+
+.. literalinclude:: ../splash/examples/element-screenshot.lua
+   :language: lua
 
 *scale_method* parameter must be either ``'raster'`` or ``'vector'``.  When
 ``scale_method='raster'``, the image is resized per-pixel.  When
@@ -1088,7 +1105,7 @@ splash:jpeg
 
 Return a `width x height` screenshot of a current page in JPEG format.
 
-**Signature:** ``jpeg = splash:jpeg{width=nil, height=nil, render_all=false, scale_method='raster', quality=75}``
+**Signature:** ``jpeg = splash:jpeg{width=nil, height=nil, render_all=false, scale_method='raster', quality=75, region=nil}``
 
 **Parameters:**
 
@@ -1096,8 +1113,10 @@ Return a `width x height` screenshot of a current page in JPEG format.
 * height - optional, height of a screenshot in pixels;
 * render_all - optional, if ``true`` render the whole webpage;
 * scale_method - optional, method to use when resizing the image, ``'raster'``
-  or ``'vector'``
-* quality - optional, quality of JPEG image, integer in range from ``0`` to ``100``
+  or ``'vector'``;
+* quality - optional, quality of JPEG image, integer in range from ``0`` to ``100``;
+* region - optional, ``{left, top, right, bottom}`` coordinates of
+  a cropping rectangle.
 
 **Returns:** JPEG screenshot data, as a :ref:`binary object <binary-objects>`.
 When the image is empty ``nil`` is returned.
@@ -1121,6 +1140,17 @@ To set the viewport size use :ref:`splash-set-viewport-size`,
 :ref:`splash-set-viewport-full` or *render_all* argument.  ``render_all=true``
 is equivalent to running ``splash:set_viewport_full()`` just before the
 rendering and restoring the viewport size afterwards.
+
+To render an arbitrary part of a page use *region* parameter. It should
+be a table with ``{left, top, right, bottom}`` coordinates. Coordinates
+are relative to current scroll position. Currently you can't take anything
+which is not in a viewport; to make sure part of a page can be rendered call
+:ref:`splash-set-viewport-full` before using :ref:`splash-jpeg` with *region*.
+This may be fixed in future Splash versions.
+
+With some JavaScript it is possible to render only a single HTML element
+using ``region`` parameter. See an
+:ref:`example <example-render-element>` in :ref:`splash-png` docs.
 
 *scale_method* parameter must be either ``'raster'`` or ``'vector'``.  When
 ``scale_method='raster'``, the image is resized per-pixel.  When

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -1020,6 +1020,7 @@ Return a `width x height` screenshot of a current page in PNG format.
   or ``'vector'``
 
 **Returns:** PNG screenshot data, as a :ref:`binary object <binary-objects>`.
+When the result is empty ``nil`` is returned.
 
 **Async:** no.
 
@@ -1065,9 +1066,16 @@ on a client (magic!):
          return {png=splash:png()}
      end
 
-If your script returns the result of ``splash:png()`` in a top-level
-``"png"`` key (as we've done in a previous example) then Splash UI
-will display it as an image.
+When an image is empty :ref:`splash-png` returns ``nil``. If you want Splash to
+raise an error in these cases use ``assert``:
+
+.. code-block:: lua
+
+     function main(splash)
+         assert(splash:go(splash.args.url))
+         local png = assert(splash:png())
+         return {png=png}
+     end
 
 See also: :ref:`splash-jpeg`, :ref:`binary-objects`,
 :ref:`splash-set-viewport-size`, :ref:`splash-set-viewport-full`.
@@ -1092,6 +1100,7 @@ Return a `width x height` screenshot of a current page in JPEG format.
 * quality - optional, quality of JPEG image, integer in range from ``0`` to ``100``
 
 **Returns:** JPEG screenshot data, as a :ref:`binary object <binary-objects>`.
+When the image is empty ``nil`` is returned.
 
 **Async:** no.
 
@@ -1148,6 +1157,17 @@ on a client:
      function main(splash)
          assert(splash:go(splash.args.url))
          return {jpeg=splash:jpeg()}
+     end
+
+When an image is empty :ref:`splash-jpeg` returns ``nil``. If you want Splash to
+raise an error in these cases use `assert`:
+
+.. code-block:: lua
+
+     function main(splash)
+         assert(splash:go(splash.args.url))
+         local jpeg = assert(splash:jpeg())
+         return {jpeg=jpeg}
      end
 
 See also: :ref:`splash-png`, :ref:`binary-objects`,

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -720,7 +720,8 @@ class BrowserTab(QObject):
         self.store_har_timing("_onHtmlRendered")
         return result
 
-    def _get_image(self, image_format, width, height, render_all, scale_method):
+    def _get_image(self, image_format, width, height, render_all,
+                   scale_method, region):
         old_size = self.web_page.viewportSize()
         try:
             if render_all:
@@ -729,7 +730,8 @@ class BrowserTab(QObject):
                 self.set_viewport('full')
             renderer = QtImageRenderer(
                 self.web_page, self.logger, image_format,
-                width=width, height=height, scale_method=scale_method)
+                width=width, height=height, scale_method=scale_method,
+                region=region)
             image = renderer.render_qwebpage()
         finally:
             if old_size != self.web_page.viewportSize():
@@ -739,13 +741,14 @@ class BrowserTab(QObject):
         return image
 
     def png(self, width=None, height=None, b64=False, render_all=False,
-            scale_method=None):
+            scale_method=None, region=None):
         """ Return screenshot in PNG format """
         self.logger.log(
             "Getting PNG: width=%s, height=%s, "
-            "render_all=%s, scale_method=%s" %
-            (width, height, render_all, scale_method), min_level=2)
-        image = self._get_image('PNG', width, height, render_all, scale_method)
+            "render_all=%s, scale_method=%s, region=%s" %
+            (width, height, render_all, scale_method, region), min_level=2)
+        image = self._get_image('PNG', width, height, render_all,
+                                scale_method, region=region)
         result = image.to_png()
         if b64:
             result = base64.b64encode(result).decode('utf-8')
@@ -753,13 +756,15 @@ class BrowserTab(QObject):
         return result
 
     def jpeg(self, width=None, height=None, b64=False, render_all=False,
-             scale_method=None, quality=None):
+             scale_method=None, quality=None, region=None):
         """Return screenshot in JPEG format."""
         self.logger.log(
             "Getting JPEG: width=%s, height=%s, "
-            "render_all=%s, scale_method=%s, quality=%s" %
-            (width, height, render_all, scale_method, quality), min_level=2)
-        image = self._get_image('JPEG', width, height, render_all, scale_method)
+            "render_all=%s, scale_method=%s, quality=%s, region=%s" %
+            (width, height, render_all, scale_method, quality, region),
+            min_level=2)
+        image = self._get_image('JPEG', width, height, render_all,
+                                scale_method, region=region)
         result = image.to_jpeg(quality=quality)
         if b64:
             result = base64.b64encode(result).decode('utf-8')

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -757,7 +757,7 @@ class BrowserTab(QObject):
 
     def jpeg(self, width=None, height=None, b64=False, render_all=False,
              scale_method=None, quality=None, region=None):
-        """Return screenshot in JPEG format."""
+        """ Return screenshot in JPEG format. """
         self.logger.log(
             "Getting JPEG: width=%s, height=%s, "
             "render_all=%s, scale_method=%s, quality=%s, region=%s" %

--- a/splash/examples/element-screenshot.lua
+++ b/splash/examples/element-screenshot.lua
@@ -1,0 +1,28 @@
+-- this function adds padding around region
+function pad(r, pad)
+  return {r[1]-pad, r[2]-pad, r[3]+pad, r[4]+pad}
+end
+
+-- main script
+function main(splash)
+
+  -- this function returns element bounding box
+  local get_bbox = splash:jsfunc([[
+    function(css) {
+      var el = document.querySelector(css);
+      var r = el.getBoundingClientRect();
+      return [r.left, r.top, r.right, r.bottom];
+    }
+  ]])
+
+  assert(splash:go(splash.args.url))
+  assert(splash:wait(0.5))
+  
+  -- don't crop image by a viewport
+  splash:set_viewport_full()  
+
+  -- let's get a screenshot of a first <a>
+  -- element on a page, with extra 32px around it
+  local region = get_bbox("a:nth-of-type(1)")
+  return splash:png{region=pad(region, 32)}
+end

--- a/splash/qtrender_image.py
+++ b/splash/qtrender_image.py
@@ -107,6 +107,10 @@ class QtImageRenderer(object):
             web_viewport = QRect(QPoint(left, top), QPoint(right - 1, bottom - 1))
         img_viewport, img_size = self._calculate_image_parameters(
             web_viewport, self.width, self.height)
+        if img_viewport.isEmpty() or img_size.isEmpty():
+            self.logger.log("requested image is empty", min_level=1)
+            return EmptyImage()
+
         self.logger.log("image render: output size=%s, viewport=%s" %
                         (img_size, img_viewport), min_level=2)
 
@@ -487,3 +491,21 @@ class WrappedPillowImage(WrappedImage):
         buf = BytesIO()
         self.img.save(buf, 'jpeg', quality=quality)
         return buf.getvalue()
+
+
+class EmptyImage(WrappedImage):
+    @property
+    def size(self):
+        return QSize()
+
+    def resize(self, new_size):
+        pass
+
+    def crop(self, rect):
+        pass
+
+    def to_png(self, complevel=defaults.PNG_COMPRESSION_LEVEL):
+        return b''
+
+    def to_jpeg(self, quality=None):
+        return b''

--- a/splash/qtrender_image.py
+++ b/splash/qtrender_image.py
@@ -46,6 +46,9 @@ class QtImageRenderer(object):
         if not (self.is_png() or self.is_jpeg()):
             raise ValueError('Unexpected image format %s, should be PNG or JPEG' %
                              self.image_format)
+        if self.region is not None and self.height:
+            raise ValueError("'height' argument is not supported when "
+                             "'region' is argument is passed")
         # For JPEG it's okay to use this format as well, but canvas should be
         # white to remove black areas from image where it was transparent
         self.qt_image_format = QImage.Format_ARGB32

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -577,6 +577,8 @@ class Splash(BaseExposedObject):
         region = self._validate_region(region)
         result = self.tab.png(width, height, b64=False, render_all=render_all,
                               scale_method=scale_method, region=region)
+        if not result:
+            return None
         return BinaryCapsule(result, 'image/png')
 
     @command()
@@ -593,6 +595,8 @@ class Splash(BaseExposedObject):
         result = self.tab.jpeg(width, height, b64=False, render_all=render_all,
                                scale_method=scale_method, quality=quality,
                                region=region)
+        if not result:
+            return None
         return BinaryCapsule(result, 'image/jpeg')
 
     def _validate_region(self, region):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -569,26 +569,40 @@ class Splash(BaseExposedObject):
 
     @command()
     def png(self, width=None, height=None, render_all=False,
-            scale_method=None):
+            scale_method=None, region=None):
         if width is not None:
             width = int(width)
         if height is not None:
             height = int(height)
+        if region is not None:
+            try:
+                region = tuple(int(region[r]) for r in range(1, 5))
+            except Exception:
+                raise ScriptError(
+                    "region must be a table containing 4 numbers"
+                    " {left, top, right, bottom} ")
         result = self.tab.png(width, height, b64=False, render_all=render_all,
-                              scale_method=scale_method)
+                              scale_method=scale_method, region=region)
         return BinaryCapsule(result, 'image/png')
 
     @command()
     def jpeg(self, width=None, height=None, render_all=False,
-             scale_method=None, quality=None):
+             scale_method=None, quality=None, region=None):
         if width is not None:
             width = int(width)
         if height is not None:
             height = int(height)
         if quality is not None:
             quality = int(quality)
+        if region is not None:
+            try:
+                region = tuple(int(region[r]) for r in range(1, 5))
+            except Exception:
+                raise ScriptError("region must be a table containing 4 numbers"
+                                  " {left, top, right, bottom} ")
         result = self.tab.jpeg(width, height, b64=False, render_all=render_all,
-                               scale_method=scale_method, quality=quality)
+                               scale_method=scale_method, quality=quality,
+                               region=region)
         return BinaryCapsule(result, 'image/jpeg')
 
     @command()

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -574,13 +574,7 @@ class Splash(BaseExposedObject):
             width = int(width)
         if height is not None:
             height = int(height)
-        if region is not None:
-            try:
-                region = tuple(int(region[r]) for r in range(1, 5))
-            except Exception:
-                raise ScriptError(
-                    "region must be a table containing 4 numbers"
-                    " {left, top, right, bottom} ")
+        region = self._validate_region(region)
         result = self.tab.png(width, height, b64=False, render_all=render_all,
                               scale_method=scale_method, region=region)
         return BinaryCapsule(result, 'image/png')
@@ -594,16 +588,23 @@ class Splash(BaseExposedObject):
             height = int(height)
         if quality is not None:
             quality = int(quality)
-        if region is not None:
-            try:
-                region = tuple(int(region[r]) for r in range(1, 5))
-            except Exception:
-                raise ScriptError("region must be a table containing 4 numbers"
-                                  " {left, top, right, bottom} ")
+
+        region = self._validate_region(region)
         result = self.tab.jpeg(width, height, b64=False, render_all=render_all,
                                scale_method=scale_method, quality=quality,
                                region=region)
         return BinaryCapsule(result, 'image/jpeg')
+
+    def _validate_region(self, region):
+        if region is not None:
+            try:
+                if isinstance(region, dict):
+                    region = [region[i] for i in range(1, 5)]
+                region = tuple(int(region[i]) for i in range(4))
+            except Exception:
+                raise ScriptError("region must be a table containing 4 numbers"
+                                  " {left, top, right, bottom} ")
+        return region
 
     @command()
     def har(self, reset=False):

--- a/splash/resources.py
+++ b/splash/resources.py
@@ -642,6 +642,7 @@ end
                                     <li><a href="#" onclick="splash.loadExample('count-divs')">Count DIV tags</a></li>
                                     <li><a href="#" onclick="splash.loadExample('call-later')">Call Later</a></li>
                                     <li><a href="#" onclick="splash.loadExample('render-png')">Render PNG</a></li>
+                                    <li><a href="#" onclick="splash.loadExample('element-screenshot')">Take a screenshot of a single element</a></li>
                                     <li><a href="#" onclick="splash.loadExample('log-requests')">Log requested URLs</a></li>
                                     <li><a href="#" onclick="splash.loadExample('block-css')">Block CSS</a></li>
                                 </ul>

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -625,7 +625,9 @@ RgbStripesPage = _html_resource("""
             #ff0000, #ff0000 1px,
             #00ff00 1px, #00ff00 2px,
             #0000ff 2px, #0000ff 3px);
-    width: 10px; height: 10px}
+        width: 10px;
+        height: 10px
+    }
   </style>
   <body>
     &nbsp

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -3135,7 +3135,7 @@ class RenderRegionTest(BaseLuaRenderTest):
         resp = self.request_lua(script, dict(
             url=self.mockurl('red-green'),
             left=region[0], top=region[1], right=region[2], bottom=region[3],
-            scale_method=kwargs.get('scale_method', 'raster')
+            scale_method=kwargs.get('scale_method', 'raster'),
         ))
         self.assertStatusCode(resp, 200)
         out = resp.json()
@@ -3150,6 +3150,19 @@ class RenderRegionTest(BaseLuaRenderTest):
 
     def test_render_region_vector(self):
         self._test_render_region_impl(scale_method='vector')
+
+    def test_empty_rect(self):
+        script = """
+        function main(splash)
+            splash:set_viewport_size(1024, 768)
+            splash:go(splash.args.url)
+            splash:wait(0.1)
+            local img = assert(splash:png{region={10, 10, 10, 10}})
+            return {img=img}
+        end
+        """
+        resp = self.request_lua(script, {'url': self.mockurl('red-green')})
+        self.assertScriptError(resp, ScriptError.LUA_ERROR, 'assertion')
 
     @pytest.mark.xfail
     def test_render_region_with_tiling(self):

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -3209,9 +3209,19 @@ class RenderRegionTest(BaseLuaRenderTest):
         # Otherwise the viewport size is limited by 20000x20000.
         raise NotImplementedError("not implemented yet")
 
-    @pytest.mark.xfail
     def test_render_region_with_resizing_and_height_trimming(self):
-        raise NotImplementedError("not implemented yet")
+        script = """
+        function main(splash)
+            splash:set_viewport_size(1024, 768)
+            splash:go(splash.args.url)
+            splash:wait(0.1)
+            local img = splash:png{region={10, 10, 30, 30}, height=100}
+            return {img=img}
+        end
+        """
+        resp = self.request_lua(script, {'url': self.mockurl('red-green')})
+        self.assertScriptError(resp, ScriptError.SPLASH_LUA_ERROR,
+                               "'height' argument is not supported")
 
     def test_render_region_errors(self):
         out = self.request_lua("""

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -144,6 +144,10 @@ class BaseRenderTest(unittest.TestCase):
                          "Region color (%s) doesn't match the etalon (%s)" %
                          (color, etalon))
 
+    def assertImagesEqual(self, img1, img2):
+        diffbox = ImageChops.difference(img1, img2).getbbox()
+        self.assertIsNone(diffbox, ("Images differ in region %s" % (diffbox,)))
+
 
 class Base(object):
     # a hack to skip running of a base RenderTest
@@ -549,10 +553,6 @@ Tiling is enabled in raster mode when any dimension of the viewport reaches
             r = self.request(query)
             img = self.assertPng(r, width=99, height=height)
             self.assertImagesEqual(full_img.crop((0, 0, 99, height)), img)
-
-    def assertImagesEqual(self, img1, img2):
-        diffbox = ImageChops.difference(img1, img2).getbbox()
-        self.assertIsNone(diffbox, ("Images differ in region %s" % (diffbox,)))
 
 
 class RenderJsonTest(Base.RenderTest):


### PR DESCRIPTION
This PR should ultimately fix #213.

It adds support for `splash:png{region={left, top, right, bottom}}` (and `splash:jpeg`, too) where the coordinates are specified relative to the viewport (so you must still use `render_all` to be able to specify absolute coordinates within a page). The rect includes `[left, right)` and `[top, bottom)` pixel ranges. Scaling & trimming should apply to the region too.