### PR TITLE
feat(scripting): add Element class with `offset` method

### DIFF
--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -833,6 +833,17 @@ class BrowserTab(QObject):
 
         return res
 
+    def select(self, selector):
+        """ Find element by its selector """
+        self.logger.log("finding element using `%s` selector" % selector, min_level=3)
+        element = self.web_page.mainFrame().findFirstElement(selector)
+
+        # TODO: change error handling, it will raise 400 error
+        assert(not element.isNull())
+
+        return WebElement(element)
+
+
 
 class _SplashHttpClient(QObject):
     """ Wrapper class for making HTTP requests on behalf of a SplashQWebPage """
@@ -1121,3 +1132,17 @@ def _get_header_value(headers, name, default=None):
         if name == to_bytes(k.lower()):
             return v
     return default
+
+class WebElement(object):
+    """ Wrapper on QWebElement"""
+
+    def __init__(self, element):
+        self._element = element
+
+    def get_offset(self):
+        coords = self._element.geometry().getRect()
+        return {
+            'left': coords[0],
+            'top': coords[1]
+        }
+

--- a/splash/examples/element-offset.lua
+++ b/splash/examples/element-offset.lua
@@ -1,0 +1,9 @@
+function main(splash)
+  local url = splash.args.url
+  assert(splash:go(url))
+  assert(splash:wait(0.5))
+	  
+  local element = splash:select('.article2 h1')
+
+  return element:offset()
+end

--- a/splash/lua_modules/element.lua
+++ b/splash/lua_modules/element.lua
@@ -1,0 +1,19 @@
+--
+-- A wrapper for element object. 
+-- It is used to safely expose additional functions
+-- to Lua runtime.
+--
+local wraputils = require("wraputils")
+
+local Element = {}
+local Element_private = {}
+
+function Element._create(py_element)
+  local self = {}
+  setmetatable(self, Element)
+  wraputils.wrap_exposed_object(py_element, self, Element_private, false)
+  wraputils.setup_property_access(py_element, self, Element)
+  return self
+end
+
+return Element

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -487,6 +487,13 @@ class Splash(BaseExposedObject):
         ))
         return cmd
 
+    @command(async=False, decode_arguments=True)
+    def select(self, selector):
+        element = Element(self.lua, self.exceptions, self.tab.select(selector))
+
+        return element.getWrapped()
+
+
     @command(async=True, decode_arguments=False)
     def go(self, url, baseurl=None, headers=None, http_method="GET", body=None, formdata=None):
         url = self.lua.lua2python(url, max_depth=1)
@@ -1320,6 +1327,23 @@ class _ExposedBoundResponse(_ExposedResponse):
     def abort(self):
         self.response.abort()
 
+
+
+class Element(BaseExposedObject):
+    def __init__(self, lua, exceptions, element):
+        super(Element, self).__init__(lua, exceptions)
+
+        self._element = element
+
+        wrapper = self.lua.eval("require('element')")
+        self._wrapped = wrapper._create(self)
+
+    @command()
+    def offset(self):
+        return self._element.get_offset()
+
+    def getWrapped(self):
+        return self._wrapped
 
 class Extras(BaseExposedObject):
     """

--- a/splash/resources.py
+++ b/splash/resources.py
@@ -650,6 +650,7 @@ end
                                     <li><a href="#" onclick="splash.loadExample('element-screenshot')">Take a screenshot of a single element</a></li>
                                     <li><a href="#" onclick="splash.loadExample('log-requests')">Log requested URLs</a></li>
                                     <li><a href="#" onclick="splash.loadExample('block-css')">Block CSS</a></li>
+                                    <li><a href="#" onclick="splash.loadExample('element-offset')">Get element's offset</a></li>
                                 </ul>
                             </div>
                             <a class="btn btn-info" href="https://github.com/scrapinghub/splash">Source code</a>

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -683,6 +683,62 @@ class CP1251Resource(Resource):
                 '''.strip().encode('cp1251')
 
 
+class TwoAbsoluteElementsResource(Resource):
+    isLeaf = True
+
+    element1 = {
+        "top": 48,
+        "left": 1516
+    }
+
+    element2 = {
+        "top": 23,
+        "left": 42
+    }
+
+    def render_GET(self, request):
+        html_code = u"""
+        <html>
+        <head>
+            <style type="text/css">
+                html, body {
+                    margin: 0;
+                    padding: 0;
+                }
+
+                .container {
+                    position: relative;
+                }
+
+                .element {
+                    width: 100px;
+                    height: 100px;
+
+                    position: absolute;
+                    top: %dpx;
+                    left: %dpx;
+
+                    background-color: red;
+                }
+
+                .element-mod {
+                    top: %dpx;
+                    left: %dpx;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <div class="element"></div>
+                <div class="element element-mod"></div>
+            </div>
+        </body>
+        </html>
+        """ % (self.element1["top"], self.element1["left"], self.element2["top"], self.element2["left"])
+
+        return html_code.encode("utf8")
+
+
 class Subresources(Resource):
     """ Embedded css and image """
 
@@ -821,6 +877,7 @@ class Root(Resource):
         self.putChild(b"echourl", EchoUrl())
         self.putChild(b"bad-content-type", InvalidContentTypeResource())
         self.putChild(b"bad-content-type2", InvalidContentTypeResource2())
+        self.putChild(b"two-absolute-elements", TwoAbsoluteElementsResource())
 
         self.putChild(b"jsredirect", JsRedirect())
         self.putChild(b"jsredirect-to", JsRedirectTo())

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -25,7 +25,7 @@ from splash.har.utils import get_response_body_bytes
 from . import test_render
 from .test_jsonpost import JsonPostRequestHandler
 from .utils import NON_EXISTING_RESOLVABLE, SplashServer
-from .mockserver import JsRender
+from .mockserver import JsRender, TwoAbsoluteElementsResource
 from .. import defaults
 
 
@@ -3456,3 +3456,52 @@ class EnableDisablePrivateModeTest(BaseLuaRenderTest):
         data = resp.json()
         self.assertIn(u'world of splash', data["html1"])
         self.assertNotIn(u"world of splash", data["html2"])
+
+
+class ElementOffsetTest(BaseLuaRenderTest):
+    def test_offset1(self):
+        resp = self.request_lua("""
+            function main(splash)
+                assert(splash:go(splash.args.url))
+                assert(splash:wait(0.5))
+
+                return splash:select('.container .element:first-child'):offset()
+            end
+        """, {"url": self.mockurl("two-absolute-elements")})
+
+        self.assertStatusCode(resp, 200)
+
+        data = resp.json()
+
+        self.assertEqual(data["top"], TwoAbsoluteElementsResource.element1["top"])
+        self.assertEqual(data["left"], TwoAbsoluteElementsResource.element1["left"])
+
+    def test_offset2(self):
+        resp = self.request_lua("""
+            function main(splash)
+                assert(splash:go(splash.args.url))
+                assert(splash:wait(0.5))
+
+                return splash:select('.container .element-mod'):offset()
+            end
+        """, {"url": self.mockurl("two-absolute-elements")})
+
+        self.assertStatusCode(resp, 200)
+
+        data = resp.json()
+
+        self.assertEqual(data["top"], TwoAbsoluteElementsResource.element2["top"])
+        self.assertEqual(data["left"], TwoAbsoluteElementsResource.element2["left"])
+
+    def test_element_not_exist(self):
+        resp = self.request_lua("""
+            function main(splash)
+                assert(splash:go(splash.args.url))
+                assert(splash:wait(0.5))
+
+                return splash:select('.container .dharma'):offset()
+            end
+        """, {"url": self.mockurl("two-absolute-elements")})
+
+        self.assertStatusCode(resp, 400)
+


### PR DESCRIPTION
I've tried to implement _Element_ class suggested in #380 
HTML element can be retrieved using _#select_ method on the _splash_ object. 

```lua
local element = splash:select('.container .title')
```

In this PR I've implemented only 1 method for this class: _#offset_. It returns a dictionary with top and left offset value like in jQuery#offset method.

There is no tests and docs update. Only one script example. I'll write them if my assumptions what'd be done is right.

Is this what #380 have suggested or I'm going to the wrong direction?  

P.S. This PR was creating for my proposal for GSoC 2016.