### PR TITLE
Make baseurl description in api.rst more verbose

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,8 +35,9 @@ url : string : required
 baseurl : string : optional
   The base url to render the page with.
 
-  If given, base HTML content will be feched from the URL given in the url
-  argument, and render using this as the base url.
+  Base HTML content will be feched from the URL given in the url
+  argument, while relative referenced resources in the HTML-text used to
+  render the page are fetched from the URL given in the baseurl argument.
 
 .. _arg-timeout:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,7 +37,8 @@ baseurl : string : optional
 
   Base HTML content will be feched from the URL given in the url
   argument, while relative referenced resources in the HTML-text used to
-  render the page are fetched from the URL given in the baseurl argument.
+  render the page are fetched using the URL given in the baseurl argument
+  as base.
 
 .. _arg-timeout:
 


### PR DESCRIPTION
Following #432 I tried to make the description for baseurl a bit more precise.