### PR TITLE
splash:set_custom_headers() should not cause segfaults

### DIFF
--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -105,7 +105,21 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
     def _on_finished(self, reply):
         reply.deleteLater()
 
+
     def createRequest(self, operation, request, outgoingData=None):
+        try:
+            return self._createRequest(operation, request, outgoingData=outgoingData)
+        except:
+            # There are too many errors that can happen in NAT, in case something happens
+            # splash will segfault. To avoid this in case of Splash NAT error we will just
+            # delegate to superclass (no splash intervention).
+            # WARNING: this can hide error from user (no more segfault on error, and response will be 200,
+            # but without intended splash behavior). This is not perfect but is better than crash.
+            self.log("internal error in _createRequest middleware", min_level=1)
+            self.log(traceback.format_exc(), min_level=1, format_msg=False)
+            return super(ProxiedQNetworkAccessManager, self).createRequest(operation, request, outgoingData)
+
+    def _createRequest(self, operation, request, outgoingData=None):
         """
         This method is called when a new request is sent;
         it must return a reply object to work with.
@@ -226,7 +240,12 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
             headers = headers.items()
 
         for name, value in headers or []:
-            request.setRawHeader(to_bytes(name), to_bytes(value))
+            try:
+                request.setRawHeader(to_bytes(name), to_bytes(value))
+            except TypeError:
+                msg = "invalid header {}: {}. Header keys and values must be string or bytes"
+                self.log(msg.format(name, value), min_level=1, format_msg=False)
+                continue
 
     def _handle_request_cookies(self, request):
         self.cookiejar.update_cookie_header(request)

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -903,7 +903,20 @@ class Splash(BaseExposedObject):
 
     @command(table_argument=True)
     def set_custom_headers(self, headers):
+        self.validate_headers(headers)
         self.tab.set_custom_headers(self.lua.lua2python(headers, max_depth=3))
+
+    def validate_headers(self, headers):
+        for key, value in headers.items():
+            try:
+                to_bytes(key), to_bytes(value)
+            except TypeError as e:
+                raise ScriptError({
+                    "message": "splash:set_custom_headers() arguments must be a table"
+                                " with strings as keys and values."
+                                "Header: `{}:{}` is not valid".format(key, value)
+                })
+
 
     @command()
     def get_viewport_size(self):

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -2551,6 +2551,21 @@ class HttpGetTest(BaseLuaRenderTest):
         self.assertEqual(headers["Header-2"], "Value 2")
         self.assertIn("user-agent", headers)
 
+    def test_get_with_integer_headers(self):
+        # header with integer value should not crash splash
+        resp = self.request_lua("""
+        function main(splash)
+            splash:set_custom_headers({
+                ["Header-1"] = "Value 1",
+                ["Header-2"] = 2
+                })
+            response = assert(splash:http_get(splash.args.url))
+            return response.request.headers
+        end
+        """, {"url": self.mockurl("jsrender")})
+        msg = "splash:set_custom_headers\(\) arguments must be a table with strings as keys and values."
+        self.assertScriptError(resp, ScriptError.SPLASH_LUA_ERROR, msg)
+
     def test_get_with_custom_ua(self):
         resp = self.request_lua("""
         function main(splash)


### PR DESCRIPTION
invalid header values (e.g. integer values) passed to splash/utils/to_bytes() in _handle_custom_headers() were causing SEGFAULT

Commit adds try except around createRequest() to avoid bugs like this in the future.
It also adds validation of custom_headers.
