### PR TITLE
Add PyResult to pass retvals and exceptions to Lua

### DIFF
--- a/splash/lua.py
+++ b/splash/lua.py
@@ -5,7 +5,7 @@ import re
 import functools
 import datetime
 
-from splash.utils import to_bytes, to_unicode
+from splash.utils import to_bytes, to_unicode, PyResult
 from twisted.python import log
 try:
     import lupa
@@ -225,6 +225,9 @@ def python2lua(lua, obj, max_depth=100, encoding='utf8', keep_tuples=True):
     def p2l(obj, depth):
         if depth <= 0:
             raise ValueError("Can't convert Python object to Lua: depth limit is reached")
+
+        if isinstance(obj, PyResult):
+            return tuple(p2l(elt, depth-1) for elt in obj.result)
 
         if isinstance(obj, dict):
             return lua.table_from({

--- a/splash/lua.py
+++ b/splash/lua.py
@@ -5,7 +5,7 @@ import re
 import functools
 import datetime
 
-from splash.utils import to_bytes, to_unicode, PyResult
+from splash.utils import to_bytes, to_unicode
 from twisted.python import log
 try:
     import lupa
@@ -314,3 +314,54 @@ def parse_error_message(error_text):
         'line_number': int(m.group(2)),
         'error': m.group(3)
     }
+
+
+class PyResult(object):
+    """Representation of Python operation result.
+
+    Usage::
+
+       return PyResult('foo', 'bar')  # same as PyResult.return_('foo', 'bar')
+
+       return PyResult.yield_(AsyncResult())
+
+       return PyResult.raise_('errmsg')
+
+    There are three ways the result might be handled in Lua (carried out by
+    wraputils:unwrap_python_result):
+
+    - ``PyResult(*args)`` (or ``PyResult.return_(*args)``)
+
+      Passes args as return values to Lua interpreter.  It is the default, so
+      you can write ``PyResult([ arg1, ... ])`` too.
+
+    - ``PyResult.raise_(error)``
+
+      Raises an error in Lua interpreter.
+
+    - ``PyResult.yield_(*args)``
+
+      Passes args asynchronously to Lua interpreter via ``coroutine.yield``
+
+    """
+    def __init__(self, *result, **kwargs):
+        operation = kwargs.get('_operation', 'return')
+        if operation not in ('return', 'raise', 'yield'):
+            raise ValueError('Invalid PyResult operation: %r' % operation)
+        self.result = (operation,) + result
+
+    def __repr__(self):
+        return '%s(%s)' % (type(self).__name__,
+                           ', '.join(repr(x) for x in self.result))
+
+    @staticmethod
+    def raise_(error):
+        return PyResult(error, _operation='raise')
+
+    @staticmethod
+    def return_(*args):
+        return PyResult(*args, _operation='return')
+
+    @staticmethod
+    def yield_(*args):
+        return PyResult(*args, _operation='yield')

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -26,7 +26,7 @@ end
 --
 function Splash:jsfunc(...)
   local func = Splash_private.jsfunc(self, ...)
-  return wraputils.unwraps_errors(func)
+  return wraputils.unwraps_python_result(func)
 end
 
 --

--- a/splash/lua_runner.py
+++ b/splash/lua_runner.py
@@ -7,8 +7,8 @@ import six
 import lupa
 
 from splash.exceptions import ScriptError
-from splash.lua import parse_error_message
-from splash.utils import truncated, PyResult, ensure_tuple
+from splash.lua import parse_error_message, PyResult, ensure_tuple
+from splash.utils import truncated
 
 
 class AsyncCommand(object):

--- a/splash/lua_runner.py
+++ b/splash/lua_runner.py
@@ -7,8 +7,8 @@ import six
 import lupa
 
 from splash.exceptions import ScriptError
-from splash.lua import parse_error_message, PyResult, ensure_tuple
-from splash.utils import truncated
+from splash.lua import parse_error_message, PyResult
+from splash.utils import truncated, ensure_tuple
 
 
 class AsyncCommand(object):

--- a/splash/lua_runner.py
+++ b/splash/lua_runner.py
@@ -24,10 +24,15 @@ class AsyncCommand(object):
         self.dispatcher = dispatcher
         self.id = id
 
-    def return_result(self, result):
+    def return_result(self, *args):
         """ Return result and resume the dispatcher. """
-        assert isinstance(result, PyResult)
-        self.dispatcher.dispatch(self.id, result)
+        self.dispatcher.dispatch(self.id, PyResult.return_(*args))
+
+    def raise_error(self, msg):
+        self.dispatcher.dispatch(self.id, PyResult.raise_(msg))
+
+    def yield_result(self, *args):
+        self.dispatcher.dispatch(self.id, PyResult.yield_(*args))
 
 
 class BaseScriptRunner(six.with_metaclass(abc.ABCMeta, object)):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -485,7 +485,7 @@ class Splash(BaseExposedObject):
             onredirect=redirect if cancel_on_redirect else False,
             onerror=error if cancel_on_error else False,
         ))
-        return PyResult(cmd, op='yield')
+        return PyResult.yield_(cmd)
 
     @command(sets_callback=True, decode_arguments=False)
     def with_timeout(self, func, timeout):
@@ -554,7 +554,7 @@ class Splash(BaseExposedObject):
             func=start
         ))
 
-        return PyResult(cmd, op='yield')
+        return PyResult.yield_(cmd)
 
     @command(decode_arguments=False)
     def go(self, url, baseurl=None, headers=None, http_method="GET", body=None, formdata=None):
@@ -631,7 +631,7 @@ class Splash(BaseExposedObject):
             body=body,
             headers=headers,
         ))
-        return PyResult(cmd, op='yield')
+        return PyResult.yield_(cmd)
 
     @command()
     def html(self):
@@ -726,7 +726,7 @@ class Splash(BaseExposedObject):
             errmsg = "JavaScript error: %s" % msg
             op = 'raise' if raise_ else 'not_ok'
             if raise_:
-                result = PyResult(errmsg, op='raise')
+                result = PyResult.raise_(errmsg)
             else:
                 result = PyResult(None, errmsg)
             cmd.return_result(result)
@@ -737,7 +737,7 @@ class Splash(BaseExposedObject):
             errback=errback,
             timeout=timeout,
         ))
-        return PyResult(cmd, op='yield')
+        return PyResult.yield_(cmd)
 
     @command()
     def private_jsfunc(self, func):
@@ -768,7 +768,7 @@ class Splash(BaseExposedObject):
         if browser_command == "http_post":
             command_args.update(dict(body=body))
         cmd = AsyncBrowserCommand(browser_command, command_args)
-        return PyResult(cmd, op='yield')
+        return PyResult.yield_(cmd)
 
     @command()
     def http_get(self, url, headers=None, follow_redirects=True):
@@ -828,7 +828,7 @@ class Splash(BaseExposedObject):
                 url=url,
                 callback=callback
             ))
-            return PyResult(cmd, op='yield')
+            return PyResult.yield_(cmd)
 
     @command()
     def autoload_reset(self):
@@ -892,7 +892,7 @@ class Splash(BaseExposedObject):
             callback=success,
             errback=error,
         ))
-        return PyResult(cmd, op='yield')
+        return PyResult.yield_(cmd)
 
     @command()
     def lock_navigation(self):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -218,10 +218,12 @@ def can_raise(meth):
 
 
 def exceptions_as_return_values(meth):
-    """
-    Decorator for allowing Python exceptions to be caught from Lua.
+    """Decorator for allowing Python exceptions to be caught from Lua.
 
-    FIXME: new docstring
+    TODO: this decorator is the last one on the way from Python to Lua and thus
+    is responsible for converting non-PyResult values to PyResult.  This is
+    suboptimal and should be fixed.
+
     """
     @functools.wraps(meth)
     def exceptions_as_return_values_wrapper(self, *args, **kwargs):
@@ -605,7 +607,7 @@ class Splash(BaseExposedObject):
                                "message": "GET request cannot have body"})
 
         if self.tab.web_page.navigation_locked:
-            return PyResult(None, 'navigation_locked')
+            return None, 'navigation_locked'
 
         def success():
             try:
@@ -709,12 +711,12 @@ class Splash(BaseExposedObject):
     def runjs(self, snippet):
         try:
             self.tab.runjs(snippet)
-            return PyResult(True)
+            return True
         except JsError as e:
             info = e.args[0]
             info['type'] = ScriptError.JS_ERROR
             info['splash_method'] = 'runjs'
-            return PyResult(None, info)
+            return None, info
 
     @command()
     def wait_for_resume(self, snippet, timeout=0):
@@ -812,7 +814,7 @@ class Splash(BaseExposedObject):
         if source is not None:
             # load source directly
             self.tab.autoload(source)
-            return PyResult(True)
+            return True
         else:
             # load JS from a remote resource
             def callback(reply):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -22,7 +22,8 @@ from splash.lua_runner import (
     AsyncCommand,
 )
 from splash.qtrender import RenderScript, stop_on_error
-from splash.lua import get_main, get_main_sandboxed, parse_error_message
+from splash.lua import (get_main, get_main_sandboxed, parse_error_message,
+                        PyResult)
 from splash.har.qt import reply2har, request2har
 from splash.har.utils import get_response_body_bytes
 from splash.render_options import RenderOptions
@@ -33,7 +34,7 @@ from splash.utils import (
     requires_attr,
     SplashJSONEncoder,
     to_unicode,
-    PyResult, ensure_tuple)
+    ensure_tuple)
 from splash.jsutils import escape_js, get_process_errors_js
 from splash.qtutils import (
     REQUEST_ERRORS_SHORT,

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -473,14 +473,13 @@ class Splash(BaseExposedObject):
             })
 
         def success():
-            cmd.return_result(PyResult(True))
+            cmd.return_result(True)
 
         def redirect(error_info):
-            cmd.return_result(PyResult(None, 'redirect'))
+            cmd.return_result(None, 'redirect')
 
         def error(error_info):
-            cmd.return_result(
-                PyResult(None, self._error_info_to_lua(error_info)))
+            cmd.return_result(None, self._error_info_to_lua(error_info))
 
         cmd = AsyncBrowserCommand("wait", dict(
             time_ms=time * 1000,
@@ -526,7 +525,7 @@ class Splash(BaseExposedObject):
 
         def timer_callback():
             run_coro.runner.stop()
-            cmd.return_result(PyResult(None, 'timeout_over'))
+            cmd.return_result(None, 'timeout_over')
 
         qtimer.timeout.connect(timer_callback)
 
@@ -535,7 +534,7 @@ class Splash(BaseExposedObject):
                 return
 
             qtimer.stop()
-            cmd.return_result(PyResult(True, *ensure_tuple(result)))
+            cmd.return_result(True, *ensure_tuple(result))
 
         def coro_error(ex):
             if not qtimer.isActive():  # pragma: no cover
@@ -544,7 +543,7 @@ class Splash(BaseExposedObject):
             qtimer.stop()
 
             info = str(ex.args[0]["error"])
-            cmd.return_result(PyResult(None, info))
+            cmd.return_result(None, info)
 
         run_coro = self.get_coroutine_run_func(
             "splash:with_timeout", func, coro_success, coro_error)
@@ -615,15 +614,14 @@ class Splash(BaseExposedObject):
                 code = self.tab.last_http_status()
                 if code and 400 <= code < 600:
                     # return HTTP errors as errors
-                    cmd.return_result(PyResult(None, "http%d" % code))
+                    cmd.return_result(None, "http%d" % code)
                 else:
-                    cmd.return_result(PyResult(True))
+                    cmd.return_result(True)
             except Exception as e:
-                cmd.return_result(PyResult(None, "internal_error"))
+                cmd.return_result(None, "internal_error")
 
         def error(error_info):
-            cmd.return_result(
-                PyResult(None, self._error_info_to_lua(error_info)))
+            cmd.return_result(None, self._error_info_to_lua(error_info))
 
         cmd = AsyncBrowserCommand("go", dict(
             url=url,
@@ -723,16 +721,14 @@ class Splash(BaseExposedObject):
     def wait_for_resume(self, snippet, timeout=0):
         def callback(result):
             assert result is not None
-            cmd.return_result(PyResult(result))
+            cmd.return_result(result)
 
         def errback(msg, raise_):
             errmsg = "JavaScript error: %s" % msg
-            op = 'raise' if raise_ else 'not_ok'
             if raise_:
-                result = PyResult.raise_(errmsg)
+                cmd.raise_error(errmsg)
             else:
-                result = PyResult(None, errmsg)
-            cmd.return_result(result)
+                cmd.return_result(None, errmsg)
 
         cmd = AsyncBrowserCommand("wait_for_resume", dict(
             js_source=snippet,
@@ -760,7 +756,7 @@ class Splash(BaseExposedObject):
             self._objects_to_clear.add(req)
             self._objects_to_clear.add(resp)
             resp_wrapped = self.response_wrapper._create(resp)
-            cmd.return_result(PyResult(resp_wrapped))
+            cmd.return_result(resp_wrapped)
 
         command_args = dict(
             url=url,
@@ -821,11 +817,11 @@ class Splash(BaseExposedObject):
             def callback(reply):
                 if reply.error():
                     reason = REQUEST_ERRORS_SHORT.get(reply.error(), '?')
-                    cmd.return_result(PyResult(None, reason))
+                    cmd.return_result(None, reason)
                 else:
                     source = bytes(reply.readAll()).decode('utf-8')
                     self.tab.autoload(source)
-                    cmd.return_result(PyResult(True))
+                    cmd.return_result(True)
 
             cmd = AsyncBrowserCommand("http_get", dict(
                 url=url,
@@ -882,11 +878,10 @@ class Splash(BaseExposedObject):
             data = data.encode('utf8')
 
         def success():
-            cmd.return_result(PyResult(True))
+            cmd.return_result(True)
 
         def error(error_info):
-            cmd.return_result(
-                PyResult(None, self._error_info_to_lua(error_info)))
+            cmd.return_result(None, self._error_info_to_lua(error_info))
 
         cmd = AsyncBrowserCommand("set_content", dict(
             data=data,

--- a/splash/utils.py
+++ b/splash/utils.py
@@ -187,57 +187,6 @@ def requires_attr(attr_name, raiser):
     return decorator
 
 
-class PyResult(object):
-    """Representation of Python operation result.
-
-    Usage::
-
-       return PyResult('foo', 'bar')  # same as PyResult.return_('foo', 'bar')
-
-       return PyResult.yield_(AsyncResult())
-
-       return PyResult.raise_('errmsg')
-
-    There are three ways the result might be handled in Lua (carried out by
-    wraputils:unwrap_python_result):
-
-    - ``PyResult(*args)`` (or ``PyResult.return_(*args)``)
-
-      Passes args as return values to Lua interpreter.  It is the default, so
-      you can write ``PyResult([ arg1, ... ])`` too.
-
-    - ``PyResult.raise_(error)``
-
-      Raises an error in Lua interpreter.
-
-    - ``PyResult.yield_(*args)``
-
-      Passes args asynchronously to Lua interpreter via ``coroutine.yield``
-
-    """
-    def __init__(self, *result, **kwargs):
-        operation = kwargs.get('_operation', 'return')
-        if operation not in ('return', 'raise', 'yield'):
-            raise ValueError('Invalid PyResult operation: %r' % operation)
-        self.result = (operation,) + result
-
-    def __repr__(self):
-        return '%s(%s)' % (type(self).__name__,
-                           ', '.join(repr(x) for x in self.result))
-
-    @staticmethod
-    def raise_(error):
-        return PyResult(error, _operation='raise')
-
-    @staticmethod
-    def return_(*args):
-        return PyResult(*args, _operation='return')
-
-    @staticmethod
-    def yield_(*args):
-        return PyResult(*args, _operation='yield')
-
-
 def ensure_tuple(val):
     """If val is not a tuple, make it a 1-tuple containing val.
 


### PR DESCRIPTION
This PR is the first step to streamline Lua<->Python interaction.

It replaces multiple specific kwargs with one generic way of passing values and exceptions from Python to Lua interpreter: `PyResult`. There are three ways the result can be handled in Lua:

- `PyResult(*args)` (or `PyResult.return_(*args)`)

      Returns args to Lua interpreter.

- `PyResult.raise_(error)`

      Raises an error in Lua interpreter.

- `PythonResult.yield_(*args)`

      Returns args asynchronously via ``coroutine.yield``

In Lua it is paired by `wraputils:unwrap_python_result` function that does what's necessary to propagate the desired result.