### PR TITLE
wraputils.lua setup_property_access shouldn't override class methods

### DIFF
--- a/splash/lua_modules/extras.lua
+++ b/splash/lua_modules/extras.lua
@@ -9,11 +9,12 @@ local Extras = {}
 local Extras_private = {}
 
 function Extras._create(py_extras)
-  local self = {}
-  setmetatable(self, Extras)
-  wraputils.wrap_exposed_object(py_extras, self, Extras_private, false)
-  wraputils.setup_property_access(py_extras, self, Extras)
-  return self
+  local extras = {}
+  setmetatable(extras, Extras)
+  Extras.__index = Extras
+  Extras.__newindex = rawset
+  wraputils.wrap_exposed_object(py_extras, extras, Extras_private, false)
+  return extras
 end
 
 return Extras

--- a/splash/lua_modules/extras.lua
+++ b/splash/lua_modules/extras.lua
@@ -8,8 +8,6 @@ local wraputils = require("wraputils")
 local Extras = {}
 local Extras_private = {}
 
-Extras.__index = Extras
-
 function Extras._create(py_extras)
   local extras = {}
   wraputils.wrap_exposed_object(py_extras, extras, Extras, Extras_private, false)

--- a/splash/lua_modules/extras.lua
+++ b/splash/lua_modules/extras.lua
@@ -8,12 +8,11 @@ local wraputils = require("wraputils")
 local Extras = {}
 local Extras_private = {}
 
+Extras.__index = Extras
+
 function Extras._create(py_extras)
   local extras = {}
-  setmetatable(extras, Extras)
-  Extras.__index = Extras
-  Extras.__newindex = rawset
-  wraputils.wrap_exposed_object(py_extras, extras, Extras_private, false)
+  wraputils.wrap_exposed_object(py_extras, extras, Extras, Extras_private, false)
   return extras
 end
 

--- a/splash/lua_modules/extras.lua
+++ b/splash/lua_modules/extras.lua
@@ -7,6 +7,7 @@ local wraputils = require("wraputils")
 
 local Extras = {}
 local Extras_private = {}
+wraputils.set_metamethods(Extras)
 
 function Extras._create(py_extras)
   local extras = {}

--- a/splash/lua_modules/request.lua
+++ b/splash/lua_modules/request.lua
@@ -4,7 +4,7 @@
 local wraputils = require("wraputils")
 local treat = require("libs/treat")
 
-local Request = wraputils.create_metatable(Request)
+local Request = wraputils.create_metatable()
 local Request_private = {}
 
 function Request._create(py_request)

--- a/splash/lua_modules/request.lua
+++ b/splash/lua_modules/request.lua
@@ -4,7 +4,7 @@
 local wraputils = require("wraputils")
 local treat = require("libs/treat")
 
-local Request = wraputils.create_metatable()
+local Request = wraputils.create_metatable(Request)
 local Request_private = {}
 
 function Request._create(py_request)
@@ -14,10 +14,6 @@ function Request._create(py_request)
     url=py_request.url,
     method=py_request.method,
   }
-
-  setmetatable(request, Request)
-  Request.__index = Request
-  Request.__newindex = rawset
 
   wraputils.wrap_exposed_object(py_request, request, Request, Request_private, false)
   return request

--- a/splash/lua_modules/request.lua
+++ b/splash/lua_modules/request.lua
@@ -6,6 +6,7 @@ local treat = require("libs/treat")
 
 local Request = wraputils.create_metatable()
 local Request_private = {}
+wraputils.set_metamethods(Request)
 
 function Request._create(py_request)
   local request = {

--- a/splash/lua_modules/request.lua
+++ b/splash/lua_modules/request.lua
@@ -8,16 +8,19 @@ local Request = wraputils.create_metatable()
 local Request_private = {}
 
 function Request._create(py_request)
-  local self = {
+  local request = {
     info=py_request.info,
     headers=treat.as_case_insensitive(py_request.headers),
     url=py_request.url,
     method=py_request.method,
   }
-  setmetatable(self, Request)
 
-  wraputils.wrap_exposed_object(py_request, self, Request, Request_private, false)
-  return self
+  setmetatable(request, Request)
+  Request.__index = Request
+  Request.__newindex = rawset
+
+  wraputils.wrap_exposed_object(py_request, request, Request, Request_private, false)
+  return request
 end
 
 return Request

--- a/splash/lua_modules/response.lua
+++ b/splash/lua_modules/response.lua
@@ -5,7 +5,7 @@ local wraputils = require("wraputils")
 local treat = require("libs/treat")
 local Request = require("request")
 
-local Response = wraputils.create_metatable(Response)
+local Response = wraputils.create_metatable()
 local Response_private = {}
 
 function Response._create(py_response)

--- a/splash/lua_modules/response.lua
+++ b/splash/lua_modules/response.lua
@@ -7,6 +7,7 @@ local Request = require("request")
 
 local Response = wraputils.create_metatable()
 local Response_private = {}
+wraputils.set_metamethods(Response)
 
 function Response._create(py_response)
   local response = {

--- a/splash/lua_modules/response.lua
+++ b/splash/lua_modules/response.lua
@@ -9,14 +9,16 @@ local Response = wraputils.create_metatable()
 local Response_private = {}
 
 function Response._create(py_response)
-  local self = {
+  local response = {
     headers=treat.as_case_insensitive(py_response.headers),
     request=Request._create(py_response.request),
   }
-  setmetatable(self, Response)
+  setmetatable(response, Response)
+  Response.__index = Response
+  Response.__newindex = rawset
 
-  wraputils.wrap_exposed_object(py_response, self, Response, Response_private, false)
-  return self
+  wraputils.wrap_exposed_object(py_response, response, Response, Response_private, false)
+  return response
 end
 
 

--- a/splash/lua_modules/response.lua
+++ b/splash/lua_modules/response.lua
@@ -5,7 +5,7 @@ local wraputils = require("wraputils")
 local treat = require("libs/treat")
 local Request = require("request")
 
-local Response = wraputils.create_metatable()
+local Response = wraputils.create_metatable(Response)
 local Response_private = {}
 
 function Response._create(py_response)
@@ -13,9 +13,6 @@ function Response._create(py_response)
     headers=treat.as_case_insensitive(py_response.headers),
     request=Request._create(py_response.request),
   }
-  setmetatable(response, Response)
-  Response.__index = Response
-  Response.__newindex = rawset
 
   wraputils.wrap_exposed_object(py_response, response, Response, Response_private, false)
   return response

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -10,7 +10,7 @@ local Request = require("request")
 --
 -- Lua wrapper for Splash Python object.
 --
-local Splash = wraputils.create_metatable(Splash)
+local Splash = wraputils.create_metatable()
 local Splash_private = {}
 
 function Splash._create(py_splash)
@@ -65,7 +65,7 @@ end
 --
 -- Timer Lua wrapper
 --
-local Timer = wraputils.create_metatable(Timer)
+local Timer = wraputils.create_metatable()
 local Timer_private = {}
 
 function Timer._create(py_timer)

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -10,14 +10,11 @@ local Request = require("request")
 --
 -- Lua wrapper for Splash Python object.
 --
-local Splash = wraputils.create_metatable()
+local Splash = wraputils.create_metatable(Splash)
 local Splash_private = {}
 
 function Splash._create(py_splash)
   local splash = { args = py_splash.args }
-  setmetatable(splash, Splash)
-  Splash.__index = Splash
-  Splash.__newindex = rawset
   wraputils.wrap_exposed_object(py_splash, splash, Splash, Splash_private, true)
   return splash
 end
@@ -68,14 +65,11 @@ end
 --
 -- Timer Lua wrapper
 --
-local Timer = wraputils.create_metatable()
+local Timer = wraputils.create_metatable(Timer)
 local Timer_private = {}
 
 function Timer._create(py_timer)
   local timer = {}
-  setmetatable(timer, Timer)
-  Timer.__index = Timer
-  Timer.__newindex = rawset
   wraputils.wrap_exposed_object(py_timer, timer, Timer, Timer_private, true)
   return timer
 end

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -12,6 +12,7 @@ local Request = require("request")
 --
 local Splash = wraputils.create_metatable()
 local Splash_private = {}
+wraputils.set_metamethods(Splash)
 
 function Splash._create(py_splash)
   local splash = { args = py_splash.args }
@@ -67,6 +68,7 @@ end
 --
 local Timer = wraputils.create_metatable()
 local Timer_private = {}
+wraputils.set_metamethods(Timer)
 
 function Timer._create(py_timer)
   local timer = {}

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -14,10 +14,12 @@ local Splash = wraputils.create_metatable()
 local Splash_private = {}
 
 function Splash._create(py_splash)
-  local self = {args=py_splash.args}
-  setmetatable(self, Splash)
-  wraputils.wrap_exposed_object(py_splash, self, Splash, Splash_private, true)
-  return self
+  local splash = { args = py_splash.args }
+  setmetatable(splash, Splash)
+  Splash.__index = Splash
+  Splash.__newindex = rawset
+  wraputils.wrap_exposed_object(py_splash, splash, Splash, Splash_private, true)
+  return splash
 end
 
 --
@@ -46,7 +48,7 @@ function Splash:on_response_headers(cb)
   if type(cb) ~= 'function' then
     error("splash:on_response_headers callback is not a function", 2)
   end
-  Splash_private.on_response_headers(self, function (response)
+  Splash_private.on_response_headers(self, function(response)
     local res = Response._create(response)
     return cb(res)
   end)
@@ -56,7 +58,7 @@ function Splash:on_response(cb)
   if type(cb) ~= 'function' then
     error("splash:on_response callback is not a function", 2)
   end
-  Splash_private.on_response(self, function (response)
+  Splash_private.on_response(self, function(response)
     local res = Response._create(response)
     return cb(res)
   end)
@@ -70,10 +72,12 @@ local Timer = wraputils.create_metatable()
 local Timer_private = {}
 
 function Timer._create(py_timer)
-  local self = {}
-  setmetatable(self, Timer)
-  wraputils.wrap_exposed_object(py_timer, self, Timer, Timer_private, true)
-  return self
+  local timer = {}
+  setmetatable(timer, Timer)
+  Timer.__index = Timer
+  Timer.__newindex = rawset
+  wraputils.wrap_exposed_object(py_timer, timer, Timer, Timer_private, true)
+  return timer
 end
 
 function Splash:call_later(cb, delay)

--- a/splash/lua_modules/wraputils.lua
+++ b/splash/lua_modules/wraputils.lua
@@ -170,6 +170,9 @@ end
 -- Create a Lua wrapper for a Python object.
 --
 local function wrap_exposed_object(py_object, self, cls, private_self, async)
+  setmetatable(self, cls)
+  cls.__newindex = rawset
+
   setup_commands(py_object, self, private_self, async)
   setup_property_access(py_object, self, cls)
 end
@@ -178,8 +181,9 @@ end
 --
 -- Return a metatable for a wrapped Python object
 --
-local function create_metatable()
+local function create_metatable(metatable)
   return {
+    __index = metatable,
     __wrapped = true
   }
 end

--- a/splash/lua_modules/wraputils.lua
+++ b/splash/lua_modules/wraputils.lua
@@ -187,6 +187,7 @@ end
 -- Set metamethods for accessing custom getters and setters
 --
 
+-- FIXME: move this function to `create_metatable` function
 local function set_metamethods(cls)
   cls.__index = function(self, index)
     if self.__getters[index] then

--- a/splash/lua_modules/wraputils.lua
+++ b/splash/lua_modules/wraputils.lua
@@ -135,31 +135,31 @@ end
 -- Handle @lua_property decorators.
 --
 local function setup_property_access(py_object, self, cls)
-  rawset(self, 'getters', {})
-  rawset(self, 'setters', {})
+  rawset(self, '__getters', {})
+  rawset(self, '__setters', {})
 
   for name, opts in pairs(py_object.lua_properties) do
-    self.getters[name] = unwraps_python_result(drops_self_argument(py_object[opts.getter]))
+    self.__getters[name] = unwraps_python_result(drops_self_argument(py_object[opts.getter]))
     if opts.setter ~= nil then
-      self.setters[name] = unwraps_python_result(drops_self_argument(py_object[opts.setter]))
+      self.__setters[name] = unwraps_python_result(drops_self_argument(py_object[opts.setter]))
     else
-      self.setters[name] = function()
+      self.__setters[name] = function()
         error("Attribute " .. name .. " is read-only.", 2)
       end
     end
   end
 
   function cls:__index(index)
-    if self.getters[index] then
-      return self.getters[index](self)
+    if self.__getters[index] then
+      return self.__getters[index](self)
     else
       return rawget(cls, index)
     end
   end
 
   function cls:__newindex(index, value)
-    if  self.setters[index] then
-      return self.setters[index](self, value)
+    if  self.__setters[index] then
+      return self.__setters[index](self, value)
     else
       return rawset(self, index, value)
     end

--- a/splash/tests/test_execute_callbacks.py
+++ b/splash/tests/test_execute_callbacks.py
@@ -834,6 +834,9 @@ class CallLaterTest(BaseLuaRenderTest):
         self.assertStatusCode(resp, 200)
         self.assertEqual(resp.text, "error")
 
+    """
+    This test check whether multiple instance of Timer class can be created simultaneously.
+    """
     def test_multiple_calls(self):
         resp = self.request_lua("""
         local treat = require('treat')

--- a/splash/tests/test_execute_callbacks.py
+++ b/splash/tests/test_execute_callbacks.py
@@ -834,6 +834,35 @@ class CallLaterTest(BaseLuaRenderTest):
         self.assertStatusCode(resp, 200)
         self.assertEqual(resp.text, "error")
 
+    def test_multiple_calls(self):
+        resp = self.request_lua("""
+        local treat = require('treat')
+        function main(splash)
+          local o = {false, false, false, false, false, false}
+
+          local timer1 = splash:call_later(function() o[1] = true end, 0.5)
+          local timer2 = splash:call_later(function() o[2] = true end, 0.5)
+          local timer3 = splash:call_later(function() o[3] = true end, 0.5)
+          local timer4 = splash:call_later(function() o[4] = true end, 0.5)
+          local timer5 = splash:call_later(function() o[5] = true end, 0.5)
+          local timer6 = splash:call_later(function() o[6] = true end, 0.5)
+
+          timer1:cancel()
+          timer2:cancel()
+          timer3:cancel()
+          timer4:cancel()
+          timer5:cancel()
+          timer6:cancel()
+
+          splash:wait(1)
+
+          return treat.as_array(o)
+        end
+        """)
+
+        self.assertStatusCode(resp, 200)
+        self.assertEqual(resp.json(), [False, False, False, False, False, False])
+
 
 class WithTimeoutTest(BaseLuaRenderTest):
     def test_with_timeout(self):


### PR DESCRIPTION
This PR fixes bug when you create multiple instances for exposed objects. For example, when you call `splash#call_later` you create a new instance of `_ExposedTimer` Python class and `Timer` Lua class.

