### PR TITLE
Fixed Core Dumped with bad encoded statusText (Fixes #521)

### DIFF
--- a/splash/har/qt.py
+++ b/splash/har/qt.py
@@ -122,7 +122,10 @@ def reply2har(reply, content=None):
         try:
             res["statusText"] = bytes(status_text, 'latin1').decode('latin1')
         except TypeError:
-            res["statusText"] = bytes(status_text).decode('latin1')
+            try:
+                res["statusText"] = bytes(status_text).decode('latin1')
+            except ValueError:
+                res["statusText"] = ""
 
     else:
         res["statusText"] = REQUEST_ERRORS_SHORT.get(reply.error(), "?")


### PR DESCRIPTION
It's just ignoring the error. A better solution would be a general per request exception handler, which would return an error through the API, instead of Core Dumping everything.