### PR TITLE
Fix splash-jupyter.

### DIFF
--- a/splash/kernel/kernel.py
+++ b/splash/kernel/kernel.py
@@ -141,7 +141,8 @@ class SplashKernel(Kernel):
         super(SplashKernel, self).__init__(**kwargs)
         self.tab = init_browser(SplashKernel.network_manager_factory)
 
-        self.lua = SplashLuaRuntime(self.sandboxed, "", ())
+        self.lua = SplashLuaRuntime(self.sandboxed, lua_package_path="",
+                                    lua_sandbox_allowed_modules=())
         self.exceptions = StoredExceptions()
         self.splash = Splash(
             lua=self.lua,

--- a/splash/lua_runner.py
+++ b/splash/lua_runner.py
@@ -67,6 +67,8 @@ class BaseScriptRunner(six.with_metaclass(abc.ABCMeta, object)):
         self.coro = coro_func(*(coro_args or []))
         self.result = ''
         self._waiting_for_result_id = self._START_CMD
+        self._is_first_iter = True
+        self._is_stopped = False
         self.dispatch(self._waiting_for_result_id)
 
     def stop(self):

--- a/splash/lua_runtime.py
+++ b/splash/lua_runtime.py
@@ -4,10 +4,8 @@ import os
 import weakref
 import contextlib
 
-import six
-
 from splash.lua import lua2python, python2lua, get_new_runtime
-from splash.utils import to_bytes, to_unicode
+from splash.utils import to_unicode
 
 
 class SplashLuaRuntime(object):


### PR DESCRIPTION
After https://github.com/scrapinghub/splash/pull/475 it became impossible to restart ScriptRunner, and this broke splash-jupyter. 