### PR TITLE
Add Xvfb parameter -nolisten tcp (Security Issue)

### DIFF
--- a/splash/xvfb.py
+++ b/splash/xvfb.py
@@ -35,6 +35,6 @@ def _get_xvfb():
     try:
         from xvfbwrapper import Xvfb
         width, height = map(int, defaults.VIEWPORT_SIZE.split("x"))
-        return Xvfb(width, height)
+        return Xvfb(width, height, nolisten="tcp")
     except ImportError:
         return None


### PR DESCRIPTION
I've seen that some times (not always) Xvfb binds to ports in the range 6000-6200. Not only that, but it binds to the address * instead of 127.0.0.1. 

Splash seems to work fine with this parameter, and I think leaving this open is a big security risk.

Ref: 
http://serverfault.com/questions/264481/bind-xvfb-on-localhost-rather-than
https://www.x.org/archive/X11R7.6/doc/man/man1/Xvfb.1.xhtml