### PR TITLE
Add libgl1-mesa-dri in Docker image to enable WebGL support

### DIFF
--- a/dockerfiles/splash/provision.sh
+++ b/dockerfiles/splash/provision.sh
@@ -65,6 +65,7 @@ install_deps () {
         netbase \
         ca-certificates \
         xvfb \
+        libgl1-mesa-dri \
         pkg-config \
         python3 \
         qt55base \


### PR DESCRIPTION
The Splash Docker image lacks the [`libgl1-mesa-dri`](http://packages.ubuntu.com/trusty/libgl1-mesa-dri) package, and so while WebGL should in principle function in Splash, it does not when run in the supplied Docker image.

Steps to reproduce:
1. Launch the Splash Docker image.
2. Navigate Splash to http://get.webgl.org.
3. Observe that the rendered page indicates that WebGL support is not available.

Expected result:
* WebGL support is available and the rendered page includes WebGL content:

![image](https://cloud.githubusercontent.com/assets/118546/24731942/76e662ca-1a3b-11e7-9eec-9b1017b13aad.png)


Fixes #548.