### PR TITLE
Update manual install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -77,14 +77,17 @@ Ubuntu 14.04 (manual way)
         $ sudo ./provision.sh install_pyqt5
        
         $ sudo ./provision.sh install_python_deps
-       
-        $ sudo ./provision.sh remove_builddeps
-       
-        $ sudo ./provision.sh remove_extra
-       
+        
         Change back to the parent directory of splash, i.e. `cd ~`
        
         $ sudo pip3 install splash/
+        
+3. **OPTIONAL** Remove packages unecessary for Splash:
+        
+        $ sudo ./provision.sh remove_builddeps
+
+        $ sudo ./provision.sh remove_extra
+
 
 To run the server execute the following command::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -81,12 +81,6 @@ Ubuntu 14.04 (manual way)
         Change back to the parent directory of splash, i.e. `cd ~`
        
         $ sudo pip3 install splash/
-        
-3. **OPTIONAL** Remove packages unnecessary for Splash:
-        
-        $ sudo ./provision.sh remove_builddeps
-
-        $ sudo ./provision.sh remove_extra
 
 
 To run the server execute the following command::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -64,19 +64,10 @@ Ubuntu 14.04 (manual way)
 
         $ cd splash/dockerfiles/splash   
         
-        $ sudo ./provision.sh prepare_install 
-        
-        $ sudo ./provision.sh install_msfonts 
-        
-        $ sudo ./provision.sh install_builddeps
-        
-        $ sudo ./provision.sh install_deps
-        
-        $ sudo ./provision.sh install_extra_fonts
-       
-        $ sudo ./provision.sh install_pyqt5
-       
-        $ sudo ./provision.sh install_python_deps
+        $ sudo ./provision.sh prepare_install install_msfonts \
+                              install_builddeps install_deps \
+                              install_extra_fonts install_pyqt5 \
+                              install_python_deps install_flash
         
         Change back to the parent directory of splash, i.e. `cd ~`
        

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -80,7 +80,7 @@ Ubuntu 14.04 (manual way)
        
         $ sudo ./provision.sh remove_builddeps
        
-        $ sudo ./provision.sh reomve_extra
+        $ sudo ./provision.sh remove_extra
        
         Change back to the parent directory of splash, i.e. `cd ~`
        

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -56,17 +56,35 @@ OS X + Docker
 Ubuntu 14.04 (manual way)
 -------------------------
 
-1. Install system dependencies (check
-`provision.sh <https://github.com/scrapinghub/splash/blob/master/dockerfiles/splash/provision.sh>`)
-
-2. Clone the repo from GitHub::
+1. Clone the repo from GitHub::
 
         $ git clone https://github.com/scrapinghub/splash/
 
-3. Install dependencies with pip::
+2. Install dependencies::
 
-        $ cd splash
-        $ pip3 install -r requirements.txt
+        $ cd splash/dockerfiles/splash   
+        
+        $ sudo ./provision.sh prepare_install 
+        
+        $ sudo ./provision.sh install_msfonts 
+        
+        $ sudo ./provision.sh install_builddeps
+        
+        $ sudo ./provision.sh install_deps
+        
+        $ sudo ./provision.sh install_extra_fonts
+       
+        $ sudo ./provision.sh install_pyqt5
+       
+        $ sudo ./provision.sh install_python_deps
+       
+        $ sudo ./provision.sh remove_builddeps
+       
+        $ sudo ./provision.sh reomve_extra
+       
+        Change back to the parent directory of splash, i.e. `cd ~`
+       
+        $ sudo pip3 install splash/
 
 To run the server execute the following command::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -82,7 +82,7 @@ Ubuntu 14.04 (manual way)
        
         $ sudo pip3 install splash/
         
-3. **OPTIONAL** Remove packages unecessary for Splash:
+3. **OPTIONAL** Remove packages unnecessary for Splash:
         
         $ sudo ./provision.sh remove_builddeps
 


### PR DESCRIPTION
It took me an unreasonable amount of time to figure out how to do a manual splash install. 

I ended up finding [this](https://hub.docker.com/r/scrapinghub/splash/builds/bog9kxd7dpkwkfjjdkyhxd/) build log to figure it out. 

Thought this may benefit others who are looking to manually install splash. This should be moved into a script in the future.