### PR TITLE
Increase default limits. See GH-209.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -69,7 +69,7 @@ wait : float : optional
   callbacks of setInterval/setTimeout won't be executed. Non-zero
   :ref:`wait <arg-wait>` is also required for PNG and JPEG rendering when doing
   full-page rendering (see :ref:`render_all <arg-render-all>`). Maximum
-  allowed value for wait is 10 seconds.
+  allowed value for wait is 30 seconds.
 
 .. _arg-proxy:
 

--- a/splash/defaults.py
+++ b/splash/defaults.py
@@ -5,7 +5,7 @@ WAIT_TIME = 0.0
 RESOURCE_TIMEOUT = 0.0
 
 MAX_TIMEOUT = 60.0
-MAX_WAIT_TIME = 10.0
+MAX_WAIT_TIME = 30.0
 
 # Default size of browser window.  As there're no decorations, this affects
 # both "window.inner*" and "window.outer*" values.

--- a/splash/lua_modules/sandbox.lua
+++ b/splash/lua_modules/sandbox.lua
@@ -173,7 +173,7 @@ end
 --
 
 -- maximum memory (in KB) that can be used by Lua script
-sandbox.mem_limit = 50000
+sandbox.mem_limit = 100000
 sandbox.mem_limit_reached = false
 
 function sandbox.enable_memory_limit()
@@ -200,7 +200,7 @@ end
 
 -- Maximum number of instructions that can be executed.
 -- XXX: the slowdown only becomes percievable at ~5m instructions.
-sandbox.instruction_limit = 1e6
+sandbox.instruction_limit = 5e6
 sandbox.instruction_count = 0
 
 function sandbox.enable_per_instruction_limits()

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -204,7 +204,8 @@ class Base(object):
             self.assertStatusCode(r, 200)
 
         def test_invalid_wait(self):
-            for wait in ['foo', '11', '11.0']:
+            wait = defaults.MAX_WAIT_TIME + 1
+            for wait in ['foo', "%d" % wait, '%0.1f' % wait]:
                 r = self.request({'url': self.mockurl("jsrender"),
                                   'wait': wait})
                 self.assertStatusCode(r, 400)


### PR DESCRIPTION
See #209 and https://stackoverflow.com/questions/44310987/splash-memory-limit-scrapy/.