### PR TITLE
Remove wait limit. Fixes GH-209.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,11 +45,11 @@ baseurl : string : optional
 timeout : float : optional
   A timeout (in seconds) for the render (defaults to 30).
 
-  By default, maximum allowed value for the timeout is 60 seconds.
+  By default, maximum allowed value for the timeout is 90 seconds.
   To override it start Splash with ``--max-timeout`` command line option.
-  For example, here Splash is configured to allow timeouts up to 2 minutes::
+  For example, here Splash is configured to allow timeouts up to 5 minutes::
 
-      $ docker run -it -p 8050:8050 scrapinghub/splash --max-timeout 120
+      $ docker run -it -p 8050:8050 scrapinghub/splash --max-timeout 300
 
 .. _arg-resource-timeout:
 
@@ -67,9 +67,10 @@ wait : float : optional
   (defaults to 0). Increase this value if you expect pages to contain
   setInterval/setTimeout javascript calls, because with wait=0
   callbacks of setInterval/setTimeout won't be executed. Non-zero
-  :ref:`wait <arg-wait>` is also required for PNG and JPEG rendering when doing
-  full-page rendering (see :ref:`render_all <arg-render-all>`). Maximum
-  allowed value for wait is 30 seconds.
+  :ref:`wait <arg-wait>` is also required for PNG and JPEG rendering when
+  doing full-page rendering (see :ref:`render_all <arg-render-all>`).
+
+  Wait time must be less than :ref:`timeout <arg-timeout>`.
 
 .. _arg-proxy:
 

--- a/splash/defaults.py
+++ b/splash/defaults.py
@@ -4,8 +4,7 @@ TIMEOUT = 30
 WAIT_TIME = 0.0
 RESOURCE_TIMEOUT = 0.0
 
-MAX_TIMEOUT = 60.0
-MAX_WAIT_TIME = 30.0
+MAX_TIMEOUT = 90.0
 
 # Default size of browser window.  As there're no decorations, this affects
 # both "window.inner*" and "window.outer*" values.

--- a/splash/render_options.py
+++ b/splash/render_options.py
@@ -122,7 +122,7 @@ class RenderOptions(object):
 
     def get_wait(self):
         return self.get("wait", defaults.WAIT_TIME, type=float,
-                        range=(0, defaults.MAX_WAIT_TIME))
+                        range=(0, self.get_timeout()))
 
     def get_timeout(self):
         default = min(self.max_timeout, defaults.TIMEOUT)

--- a/splash/resources.py
+++ b/splash/resources.py
@@ -115,10 +115,8 @@ class BaseRenderResource(_ValidatingResource):
         render_options.get_filters(self.pool)
 
         timeout = render_options.get_timeout()
-        wait_time = render_options.get_wait()
-
         pool_d = self._get_render(request, render_options)
-        timer = reactor.callLater(timeout+wait_time, pool_d.cancel)
+        timer = reactor.callLater(timeout, pool_d.cancel)
         request.notifyFinish().addErrback(self._request_failed, pool_d, timer)
 
         pool_d.addCallback(self._cancel_timer, timer)

--- a/splash/tests/test_execute_emulation.py
+++ b/splash/tests/test_execute_emulation.py
@@ -27,6 +27,13 @@ class Base:
             r = self.request({"url": "http://non-existent-host/"})
             err = self.assertJsonError(r, 400)
 
+        @pytest.mark.xfail(
+            run=False,
+            reason="wait time validation is not implemented in emulation scripts"
+        )
+        def test_invalid_wait(self):
+            super().test_invalid_wait()
+
         def test_self(self):
             # make sure mixin order is correct
             assert self.endpoint == 'execute'

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -204,7 +204,7 @@ class Base(object):
             self.assertStatusCode(r, 200)
 
         def test_invalid_wait(self):
-            wait = defaults.MAX_WAIT_TIME + 1
+            wait = defaults.TIMEOUT + 1
             for wait in ['foo', "%d" % wait, '%0.1f' % wait]:
                 r = self.request({'url': self.mockurl("jsrender"),
                                   'wait': wait})


### PR DESCRIPTION
* wait limit is removed;
* default timeout limit is increased to 90s;
* wait no longer contributes to timeout.