### PR TITLE
Call OneShotCallbackProxy errback once

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [tool:pytest]
 norecursedirs = bin debian dist docs examples notebooks splash/kernel
 doctest_optionflags = ALLOW_UNICODE
+addopts = --tb=short

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -1466,11 +1466,15 @@ class OneShotCallbackProxy(QObject):
         self._errback(message, raise_)
 
     def cancel(self, reason):
+        if self._used_up:
+            return
         self.use_up()
         self._errback("One shot callback canceled due to: %s." % reason,
                       raise_=False)
 
     def _timed_out(self):
+        if self._used_up:
+            return
         self.use_up()
         self._errback("One shot callback timed out while waiting for"
                       " resume() or error().", raise_=False)

--- a/splash/kernel/kernel.py
+++ b/splash/kernel/kernel.py
@@ -73,6 +73,7 @@ class DeferredSplashRunner(object):
             log=self.log,
             splash=splash,
             sandboxed=self.sandboxed,
+            strict=False,
         )
 
     def run(self, main_coro):

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -2155,9 +2155,14 @@ class SplashCoroutineRunner(BaseScriptRunner):
     """
     Utility class for running Splash async functions (e.g. callbacks).
     """
-    def __init__(self, lua, splash, log, sandboxed):
+    def __init__(self, lua, splash, log, sandboxed, strict):
         self.splash = splash
-        super(SplashCoroutineRunner, self).__init__(lua=lua, log=log, sandboxed=sandboxed)
+        super(SplashCoroutineRunner, self).__init__(
+            lua=lua,
+            log=log,
+            sandboxed=sandboxed,
+            strict=strict,
+        )
 
     def start(self, coro_func, coro_args=None, return_result=None, return_error=None):
         do_nothing = lambda *args, **kwargs: None
@@ -2180,19 +2185,25 @@ class MainCoroutineRunner(SplashCoroutineRunner):
     """
     Utility class for running main Splash Lua coroutine.
     """
-    def __init__(self, lua, splash, log, sandboxed):
+    def __init__(self, lua, splash, log, sandboxed, strict):
         self.exceptions = splash.exceptions
         super(MainCoroutineRunner, self).__init__(
             lua=lua,
             splash=splash,
             log=log,
-            sandboxed=sandboxed
+            sandboxed=sandboxed,
+            strict=strict,
         )
 
     def start(self, main_coro, return_result=None, return_error=None):
         self.exceptions.clear()
         args = [self.splash.get_wrapped()]
-        super(MainCoroutineRunner, self).start(main_coro, args, return_result, return_error)
+        super(MainCoroutineRunner, self).start(
+            coro_func=main_coro,
+            coro_args=args,
+            return_result=return_result,
+            return_error=return_error
+        )
 
     def on_result(self, result):
         # Request writer expects JSON-like values and misbehaves when the
@@ -2255,7 +2266,7 @@ class LuaRender(RenderScript):
 
     @stop_on_error
     def start(self, lua_source, sandboxed, lua_package_path,
-              lua_sandbox_allowed_modules):
+              lua_sandbox_allowed_modules, strict=False):
         self.exceptions = StoredExceptions()
         self.log(lua_source)
         self.sandboxed = sandboxed
@@ -2274,6 +2285,7 @@ class LuaRender(RenderScript):
             splash=self.splash,
             log=self.log,
             sandboxed=sandboxed,
+            strict=strict,
         )
 
         try:

--- a/splash/resources.py
+++ b/splash/resources.py
@@ -270,11 +270,13 @@ class ExecuteLuaScriptResource(BaseRenderResource):
                  lua_sandbox_allowed_modules,
                  max_timeout,
                  argument_cache,
+                 strict,
                  ):
         BaseRenderResource.__init__(self, pool, max_timeout, argument_cache)
         self.sandboxed = sandboxed
         self.lua_package_path = lua_package_path
         self.lua_sandbox_allowed_modules = lua_sandbox_allowed_modules
+        self.strict = strict
 
     def _get_render(self, request, options):
         params = dict(
@@ -283,6 +285,7 @@ class ExecuteLuaScriptResource(BaseRenderResource):
             sandboxed=self.sandboxed,
             lua_package_path=self.lua_package_path,
             lua_sandbox_allowed_modules=self.lua_sandbox_allowed_modules,
+            strict=self.strict,
         )
         return self.pool.render(LuaRender, options, **params)
 
@@ -557,6 +560,7 @@ class Root(Resource):
                  lua_sandbox_allowed_modules,
                  max_timeout,
                  argument_cache_max_entries,
+                 strict_lua_runner,
                  ):
         Resource.__init__(self)
         self.argument_cache = ArgumentCache(argument_cache_max_entries)
@@ -585,6 +589,7 @@ class Root(Resource):
                 lua_sandbox_allowed_modules=lua_sandbox_allowed_modules,
                 max_timeout=max_timeout,
                 argument_cache=self.argument_cache,
+                strict=strict_lua_runner,
             ))
 
         if self.ui_enabled:

--- a/splash/server.py
+++ b/splash/server.py
@@ -54,6 +54,8 @@ def parse_opts(jupyter=False, argv=sys.argv):
              "Each place can have a ? in it that's replaced with the module name.")
     op.add_option("--lua-sandbox-allowed-modules", default="",
         help="semicolon-separated list of Lua module names allowed to be required from a sandbox.")
+    op.add_option("--strict-lua-runner", action="store_true", default=False,
+        help="enable additional internal checks for Lua scripts (WARNING: for debugging only)")
     op.add_option("-v", "--verbosity", type=int, default=defaults.VERBOSITY,
         help="verbosity level; valid values are integers from 0 to 5 (default: %default)")
     op.add_option("--version", action="store_true",
@@ -170,6 +172,7 @@ def splash_server(portnum, slots, network_manager_factory, max_timeout,
                   lua_sandbox_enabled=True,
                   lua_package_path="",
                   lua_sandbox_allowed_modules=(),
+                  strict_lua_runner=False,
                   argument_cache_max_entries=None,
                   verbosity=None):
     from twisted.internet import reactor
@@ -219,6 +222,7 @@ def splash_server(portnum, slots, network_manager_factory, max_timeout,
         lua_sandbox_allowed_modules=lua_sandbox_allowed_modules,
         max_timeout=max_timeout,
         argument_cache_max_entries=argument_cache_max_entries,
+        strict_lua_runner=strict_lua_runner,
     )
     factory = Site(root)
     reactor.listenTCP(portnum, factory)
@@ -262,6 +266,7 @@ def default_splash_server(portnum, max_timeout, slots=None,
                           lua_sandbox_enabled=True,
                           lua_package_path="",
                           lua_sandbox_allowed_modules=(),
+                          strict_lua_runner=False,
                           argument_cache_max_entries=None,
                           verbosity=None,
                           server_factory=splash_server):
@@ -285,6 +290,7 @@ def default_splash_server(portnum, max_timeout, slots=None,
         lua_sandbox_enabled=lua_sandbox_enabled,
         lua_package_path=lua_package_path,
         lua_sandbox_allowed_modules=lua_sandbox_allowed_modules,
+        strict_lua_runner=strict_lua_runner,
         verbosity=verbosity,
         max_timeout=max_timeout,
         argument_cache_max_entries=argument_cache_max_entries,
@@ -365,6 +371,7 @@ def main(jupyter=False, argv=sys.argv, server_factory=splash_server):
             lua_sandbox_enabled=not opts.disable_lua_sandbox,
             lua_package_path=opts.lua_package_path.strip(";"),
             lua_sandbox_allowed_modules=opts.lua_sandbox_allowed_modules.split(";"),
+            strict_lua_runner=opts.strict_lua_runner,
             verbosity=opts.verbosity,
             max_timeout=opts.max_timeout,
             argument_cache_max_entries=opts.argument_cache_max_entries,

--- a/splash/tests/conftest.py
+++ b/splash/tests/conftest.py
@@ -30,6 +30,19 @@ def class_splash_unrestricted(request, splash_unrestricted):
     yield splash_unrestricted
 
 
+@pytest.yield_fixture(scope="session")
+def splash_strict_lua_runner():
+    with SplashServer(extra_args=['--strict-lua-runner']) as splash:
+        yield splash
+
+
+@pytest.yield_fixture(scope="class")
+def class_splash_strict_lua_runner(request, splash_strict_lua_runner):
+    """ Splash server with additional internal checks for Lua scripts """
+    request.cls.splash_strict_lua_runner = splash_strict_lua_runner
+    yield splash_strict_lua_runner
+
+
 @pytest.fixture()
 def lua(request):
     import lupa

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -953,6 +953,14 @@ class WaitForResumeTest(BaseLuaRenderTest):
         self.assertStatusCode(resp, 200)
         self.assertEqual(resp.json(), {"value": "ok", "value_type": "string"})
 
+    def test_no_resume(self):
+        resp = self.request_lua("""
+        function main(splash)
+            return assert(splash:wait_for_resume("function main(splash){}"))
+        end
+        """, {'timeout': 1})
+        self.assertJsonError(resp, 504)
+
 
 class RunjsTest(BaseLuaRenderTest):
     def test_define_variable(self):

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -666,8 +666,14 @@ class EvaljsTest(BaseLuaRenderTest):
         self.assertEqual(err['info']['js_error_message'], 'ABC')
 
 
+@pytest.mark.usefixtures("class_splash_strict_lua_runner")
 class WaitForResumeTest(BaseLuaRenderTest):
     maxDiff = 2000
+
+    def request_lua(self, code, query=None, **kwargs):
+        endpoint = self.splash_strict_lua_runner.url('execute')
+        kwargs.setdefault('endpoint', endpoint)
+        return super().request_lua(code, query, **kwargs)
 
     def _wait_for_resume_request(self, js, timeout=1.0):
         return self.request_lua("""
@@ -961,7 +967,7 @@ class WaitForResumeTest(BaseLuaRenderTest):
         """, {'timeout': 1})
         self.assertJsonError(resp, 504)
 
-    def test_no_resume_clear_callback(self):
+    def test_no_out_of_order_results(self):
         resp = self.request_lua("""
         function main(splash)
             local script = [[

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -3058,9 +3058,9 @@ class GetPerfStatsTest(BaseLuaRenderTest):
         self.assertLess(out['cputime'], 1000.)
         self.assertLess(0., out['cputime'])
         # Should be safe to assume that splash process consumes between 1Mb
-        # and 1Gb of RAM, right?
+        # and 2Gb of RAM, right?
         self.assertLess(1E6, out['maxrss'])
-        self.assertLess(out['maxrss'], 1E9)
+        self.assertLess(out['maxrss'], 2E9)
         # I wonder if we could break this test...
         now = time.time()
         self.assertLess(now - 120, out['walltime'])

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -4,7 +4,7 @@ import unittest
 import base64
 from functools import wraps
 from io import BytesIO
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin
 
 import pytest
 import requests
@@ -48,11 +48,11 @@ class DirectRequestHandler(object):
 
     def _url_and_params(self, endpoint, query):
         endpoint = endpoint if endpoint is not None else self.endpoint
+        url = urljoin("http://%s/" % self.host, endpoint)
         if isinstance(query, dict):
-            url = "http://%s/%s" % (self.host, endpoint)
             params = query
         else:
-            url = "http://%s/%s?%s" % (self.host, endpoint, query)
+            url = "%s?%s" % (url, query)
             params = None
         return url, params
 
@@ -86,7 +86,8 @@ class BaseRenderTest(unittest.TestCase):
         return self._get_handler().post(query, endpoint, payload, headers, **kwargs)
 
     def assertStatusCode(self, response, code):
-        msg = (response.status_code, truncated(response.text, 1000))
+        msg = (response.status_code, truncated(response.text, 1000),
+               response.url)
         self.assertEqual(response.status_code, code, msg)
 
     def assertJsonError(self, response, code, error_type=None):


### PR DESCRIPTION
Previously it was possible for errback to be called multiple times when callback is cancelled at redirect.