### PR TITLE
support `function main(splash, args)`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,9 +30,12 @@ Backwards incompatible changes:
 
 Other changes:
 
-* New :ref:`splash-scroll-position` attribute allows to get and set
+* An alternative way to access :ref:`splash-args`: it can be received
+  as a second argument of ``main`` function
+  (i.e. ``function main(splash, args) ...``);
+* new :ref:`splash-scroll-position` attribute allows to get and set
   window scroll position;
-* Qt is upgraded to 5.9.1 LTS, PyQT is upgraded to 5.9;
+* Qt is upgraded to 5.9.1, PyQT is upgraded to 5.9;
 * Docker now uses Ubuntu 16.04;
 * default :ref:`timeout <arg-timeout>` **limit** (i.e. max allowed value)
   is increased from 60s to 90s; default ``timeout`` **value**

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -3,8 +3,8 @@
 Splash Scripts Reference
 ========================
 
-``splash`` object is passed to ``main`` function; via this object
-a script can control the browser. Think of it as of an API to
+``splash`` object is passed to ``main`` function as a first argument;
+via this object a script can control the browser. Think of it as of an API to
 a single browser tab.
 
 Attributes
@@ -22,10 +22,29 @@ values sent using ``application/json`` POST request.
 For example, if you passed 'url' argument to a script using HTTP API,
 then ``splash.args.url`` contains this URL.
 
-:ref:`splash-args` is the preferred way to pass parameters to Splash scripts.
-An alternative way is to use string formatting to build a script with
-variables embedded. There are two problems which make :ref:`splash-args`
-a better solution:
+You can also access ``splash.args`` using second, optional ``args`` argument
+of the ``main`` function:
+
+.. code-block:: lua
+
+    function main(splash, args)
+        local url = args.url
+        -- ...
+    end
+
+The example above is the same as
+
+.. code-block:: lua
+
+    function main(splash)
+        local url = splash.args.url
+        -- ...
+    end
+
+Using either ``args`` or :ref:`splash-args` is the preferred way to pass
+parameters to Splash scripts. An alternative way is to use string
+formatting to build a script with variables embedded.
+There are two problems which make :ref:`splash-args` a better solution:
 
 1. data must be escaped somehow, so that it doesn't break a Lua script;
 2. embedding variables makes it impossible to use script cache efficiently
@@ -1278,11 +1297,11 @@ a binary image data with a proper Content-Type header:
 .. code-block:: lua
 
      -- A simplistic implementation of render.jpeg endpoint
-     function main(splash)
-         assert(splash:go(splash.args.url))
+     function main(splash, args)
+         assert(splash:go(args.url))
          return splash:jpeg{
-            width=splash.args.width,
-            height=splash.args.height
+            width=args.width,
+            height=args.height
          }
      end
 
@@ -1353,10 +1372,10 @@ all existing logs and start recording from scratch:
 
 .. code-block:: lua
 
-     function main(splash)
-         assert(splash:go(splash.args.url1))
+     function main(splash, args)
+         assert(splash:go(args.url1))
          local har1 = splash:har{reset=true}
-         assert(splash:go(splash.args.url2))
+         assert(splash:go(args.url2))
          local har2 = splash:har()
          return {har1=har1, har2=har2}
      end
@@ -2551,18 +2570,18 @@ arguments passed to splash, `username` and `password`.
 
 .. code-block:: lua
 
-    function main(splash)
+    function main(splash, args)
         function focus(sel)
-            splash:select(sel).node:focus()
+            splash:select(sel):focus()
         end
 
-        assert(splash:go(splash.args.url))
+        assert(splash:go(args.url))
         assert(splash:wait(0.5))
         focus('input[name=username]')
-        splash:send_text(splash.args.username)
+        splash:send_text(args.username)
         assert(splash:wait(0))
         focus('input[name=password]')
-        splash:send_text(splash.args.password)
+        splash:send_text(args.password)
         splash:select('input[type=submit]'):mouse_click()
         assert(splash:wait(0))
         -- Usually, wait for the submit request to finish

--- a/splash/examples/block-css.lua
+++ b/splash/examples/block-css.lua
@@ -1,10 +1,10 @@
-function main(splash)
+function main(splash, args)
     splash:on_response_headers(function(response)
         local content_type = response.headers["Content-Type"]
         if content_type == "text/css" then
             response.abort()
         end
     end)
-    assert(splash:go(splash.args.url))
+    assert(splash:go(args.url))
     return splash:png()
 end

--- a/splash/examples/call-later.lua
+++ b/splash/examples/call-later.lua
@@ -1,11 +1,11 @@
-function main(splash)
+function main(splash, args)
     local snapshots = {}
     local timer = splash:call_later(function()
         snapshots["a"] = splash:html()
         splash:wait(1.0)
         snapshots["b"] = splash:html()
     end, 1.5)
-    assert(splash:go(splash.args.url))
+    assert(splash:go(args.url))
     splash:wait(3.0)
     timer:reraise()
     return snapshots

--- a/splash/examples/count-divs.lua
+++ b/splash/examples/count-divs.lua
@@ -1,4 +1,4 @@
-function main(splash)
+function main(splash, args)
   local get_div_count = splash:jsfunc([[
     function () {
       var body = document.body;
@@ -7,8 +7,7 @@ function main(splash)
     }
   ]])
 
-  local url = splash.args.url
-  splash:go(url)
+  splash:go(args.url)
   return string.format("There are %s DIVs in %s",
-      get_div_count(), url)
+      get_div_count(), args.url)
 end

--- a/splash/examples/render-png.lua
+++ b/splash/examples/render-png.lua
@@ -1,8 +1,8 @@
 -- A simplistic implementation of render.png endpoint
-function main(splash)
-   assert(splash:go(splash.args.url))
+function main(splash, args)
+   assert(splash:go(args.url))
    return splash:png{
-      width=splash.args.width,
-      height=splash.args.height
+      width=args.width,
+      height=args.height
    }
 end

--- a/splash/examples/scroll.lua
+++ b/splash/examples/scroll.lua
@@ -1,5 +1,5 @@
-function main(splash)
-    splash:go(splash.args.url)
+function main(splash, args)
+    splash:go(args.url)
     local scroll_to = splash:jsfunc("window.scrollTo")
     scroll_to(0, 300)
     return {png=splash:png()}

--- a/splash/examples/with-timeout.lua
+++ b/splash/examples/with-timeout.lua
@@ -1,8 +1,7 @@
-function main(splash)
+function main(splash, args)
   local ok, result = splash:with_timeout(function()
-    local url = splash.args.url
     splash:wait(3)
-    assert(splash:go(url))
+    assert(splash:go(args.url))
   end, 2)
 
   if not ok then

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -2254,7 +2254,7 @@ class MainCoroutineRunner(SplashCoroutineRunner):
 
     def start(self, main_coro, return_result=None, return_error=None):
         self.exceptions.clear()
-        args = [self.splash.get_wrapped()]
+        args = [self.splash.get_wrapped(), self.splash.args]
         super(MainCoroutineRunner, self).start(
             coro_func=main_coro,
             coro_args=args,

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -1414,18 +1414,25 @@ class ArgsTest(BaseLuaRenderTest):
         """
         return self.request_lua(func, query)
 
+    def args_param_request(self, query):
+        func = """
+        function main(splash, args)
+          return {args=args}
+        end
+        """
+        return self.request_lua(func, query)
+
     def assertArgs(self, query):
-        resp = self.args_request(query)
-        self.assertStatusCode(resp, 200)
-        data = resp.json()["args"]
-        data.pop('lua_source')
-        data.pop('uid')
-        return data
+        for resp in [self.args_request(query), self.args_param_request(query)]:
+            self.assertStatusCode(resp, 200)
+            data = resp.json()["args"]
+            data.pop('lua_source')
+            data.pop('uid')
+            yield data
 
     def assertArgsPassed(self, query):
-        args = self.assertArgs(query)
-        self.assertEqual(args, query)
-        return args
+        for args in self.assertArgs(query):
+            self.assertEqual(args, query)
 
     def test_known_args(self):
         self.assertArgsPassed({"wait": "1.0"})


### PR DESCRIPTION
A shortcut to make `splash.args` less cumbersome if there is a lot of arguments.