### PR TITLE
/run endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Other changes:
 * An alternative way to access :ref:`splash-args`: it can be received
   as a second argument of ``main`` function
   (i.e. ``function main(splash, args) ...``);
+* new :ref:`run` endpoint is an alternative to :ref:`execute` endpoint; it is
+  almost the same, but it doesn't require putting code into
+  ``function main(splash, args) ... end``;
 * new :ref:`splash-scroll-position` attribute allows to get and set
   window scroll position;
 * Qt is upgraded to 5.9.1, PyQT is upgraded to 5.9;

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,8 +7,9 @@ Splash is controlled via HTTP API. For all endpoints below parameters
 may be sent either as GET arguments or encoded to JSON and
 POSTed with ``Content-Type: application/json`` header.
 
-The most versatile endpoint that provides all Splash features
-is :ref:`execute`; it allows to execute arbitrary Lua rendering scripts.
+Most versatile endpoints that provide all Splash features
+are :ref:`execute` and :ref:`run`; they allow to execute arbitrary Lua
+rendering scripts.
 
 Other endpoints may be easier to use in specific
 cases - for example, :ref:`render.png` returns a screenshot in PNG format
@@ -620,6 +621,31 @@ load_args : JSON object or a string : optional
 
 You can pass any other arguments. All arguments passed to :ref:`execute`
 endpoint are available in a script in :ref:`splash.args <splash-args>` table.
+
+.. _run:
+
+run
+---
+
+This endpoint is the same as :ref:`execute`, but it wraps ``lua_source``
+in ``function main(splash, args) ... end`` automatically.
+For example, if you're sending this script to :ref:`execute`:
+
+.. code-block:: lua
+
+    funcion main(splash, args)
+        assert(splash:go(args.url))
+        assert(splash:wait(1.0))
+        return splash:html()
+    end
+
+equivalent script for :ref:`run` endpoint would be
+
+.. code-block:: lua
+
+    assert(splash:go(args.url))
+    assert(splash:wait(1.0))
+    return splash:html()
 
 .. _execute javascript:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -47,7 +47,7 @@ better not to wait for them forever.
 To abort resource loading after a timeout and give the whole page a chance to
 render use resource timeouts. For render.*** endpoints use
 :ref:`'resource_timeout' <arg-resource-timeout>` argument;
-for :ref:`execute` use either :ref:`splash-resource-timeout` or
+for :ref:`execute` or :ref:`run` use either :ref:`splash-resource-timeout` or
 ``request:set_timeout`` (see :ref:`splash-on-request`).
 
 It is a good practive to always set resource_timeout; something similar to

--- a/docs/kernel.rst
+++ b/docs/kernel.rst
@@ -85,10 +85,20 @@ From Notebook to HTTP API
 
 After you finished developing the script using Splash Notebook,
 you may want to convert it to a form suitable for submitting
-to Splash HTTP API (see :ref:`execute`).
+to Splash HTTP API (see :ref:`execute` and :ref:`run`).
 
 To do that, copy-paste (or download using "File -> Download as -> .lua")
-all relevant code, then put it inside ``function main(splash)``:
+all relevant code. For :ref:`run` endpoint add ``return`` statement to
+return the final result:
+
+.. code-block:: lua
+
+    -- Script code goes here,
+    -- including all helper functions.
+    return {...}  -- return the result
+
+For :ref:`execute` add ``return`` statement and put the code
+inside ``function main(splash)``:
 
 .. code-block:: lua
 

--- a/docs/scripting-tutorial.rst
+++ b/docs/scripting-tutorial.rst
@@ -11,7 +11,8 @@ programming language. This allows us to use Splash as a browser automation
 tool similar to PhantomJS_.
 
 To execute a script and get the result back send it to the :ref:`execute`
-endpoint in a :ref:`lua_source <arg-lua-source>` argument.
+(or :ref:`run`) endpoint in a :ref:`lua_source <arg-lua-source>` argument.
+We'll be using :ref:`execute` endpoint in this tutorial.
 
 .. note::
 
@@ -43,7 +44,7 @@ Let's start with a basic example:
 
 If we submit this script to the :ref:`execute` endpoint in a ``lua_source``
 argument, Splash will go to the example.com website, wait until it loads,
-wait aother half-second, then get the page title (by evaluating a JavaScript
+wait another half-second, then get the page title (by evaluating a JavaScript
 snippet in page context), and then return the result as a JSON encoded object.
 
 .. note::

--- a/splash/examples/block-css.lua
+++ b/splash/examples/block-css.lua
@@ -1,10 +1,12 @@
-function main(splash, args)
-    splash:on_response_headers(function(response)
-        local content_type = response.headers["Content-Type"]
-        if content_type == "text/css" then
-            response.abort()
-        end
-    end)
-    assert(splash:go(args.url))
-    return splash:png()
-end
+splash:on_response_headers(function(response)
+  local ct = response.headers["Content-Type"]
+  if ct == "text/css" then
+    response.abort()
+  end
+end)
+
+assert(splash:go(args.url))
+return {
+  png=splash:png(),
+  har=splash:har()
+}

--- a/splash/examples/block-css.lua
+++ b/splash/examples/block-css.lua
@@ -1,12 +1,14 @@
-splash:on_response_headers(function(response)
-  local ct = response.headers["Content-Type"]
-  if ct == "text/css" then
-    response.abort()
-  end
-end)
+function main(splash, args)
+  splash:on_response_headers(function(response)
+    local ct = response.headers["Content-Type"]
+    if ct == "text/css" then
+      response.abort()
+    end
+  end)
 
-assert(splash:go(args.url))
-return {
-  png=splash:png(),
-  har=splash:har()
-}
+  assert(splash:go(args.url))
+  return {
+    png=splash:png(),
+    har=splash:har()
+  }
+end

--- a/splash/examples/call-later.lua
+++ b/splash/examples/call-later.lua
@@ -1,12 +1,11 @@
-function main(splash, args)
-    local snapshots = {}
-    local timer = splash:call_later(function()
-        snapshots["a"] = splash:html()
-        splash:wait(1.0)
-        snapshots["b"] = splash:html()
-    end, 1.5)
-    assert(splash:go(args.url))
-    splash:wait(3.0)
-    timer:reraise()
-    return snapshots
-end
+local snapshots = {}
+local timer = splash:call_later(function()
+    snapshots["a"] = splash:html()
+    splash:wait(1.0)
+    snapshots["b"] = splash:html()
+end, 1.5)
+assert(splash:go(args.url))
+splash:wait(3.0)
+timer:reraise()
+
+return snapshots

--- a/splash/examples/call-later.lua
+++ b/splash/examples/call-later.lua
@@ -1,11 +1,13 @@
-local snapshots = {}
-local timer = splash:call_later(function()
+function main(splash, args)
+  local snapshots = {}
+  local timer = splash:call_later(function()
     snapshots["a"] = splash:html()
     splash:wait(1.0)
     snapshots["b"] = splash:html()
-end, 1.5)
-assert(splash:go(args.url))
-splash:wait(3.0)
-timer:reraise()
+  end, 1.5)
+  assert(splash:go(args.url))
+  splash:wait(3.0)
+  timer:reraise()
 
-return snapshots
+  return snapshots
+end

--- a/splash/examples/count-divs.lua
+++ b/splash/examples/count-divs.lua
@@ -1,11 +1,13 @@
-local get_div_count = splash:jsfunc([[
-function () {
-  var body = document.body;
-  var divs = body.getElementsByTagName('div');
-  return divs.length;
-}
-]])
-splash:go(args.url)
+function main(splash, args)
+  local get_div_count = splash:jsfunc([[
+  function () {
+    var body = document.body;
+    var divs = body.getElementsByTagName('div');
+    return divs.length;
+  }
+  ]])
+  splash:go(args.url)
 
-return ("There are %s DIVs in %s"):format(
-  get_div_count(), args.url)
+  return ("There are %s DIVs in %s"):format(
+    get_div_count(), args.url)
+end

--- a/splash/examples/count-divs.lua
+++ b/splash/examples/count-divs.lua
@@ -1,13 +1,11 @@
-function main(splash, args)
-  local get_div_count = splash:jsfunc([[
-    function () {
-      var body = document.body;
-      var divs = body.getElementsByTagName('div');
-      return divs.length;
-    }
-  ]])
+local get_div_count = splash:jsfunc([[
+function () {
+  var body = document.body;
+  var divs = body.getElementsByTagName('div');
+  return divs.length;
+}
+]])
+splash:go(args.url)
 
-  splash:go(args.url)
-  return string.format("There are %s DIVs in %s",
-      get_div_count(), args.url)
-end
+return ("There are %s DIVs in %s"):format(
+  get_div_count(), args.url)

--- a/splash/examples/disable-images.lua
+++ b/splash/examples/disable-images.lua
@@ -1,3 +1,5 @@
-splash.images_enabled = false
-assert(splash:go(splash.args.url))
-return {png=splash:png()}
+function main(splash, args)
+  splash.images_enabled = false
+  assert(splash:go(splash.args.url))
+  return {png=splash:png()}
+end

--- a/splash/examples/disable-images.lua
+++ b/splash/examples/disable-images.lua
@@ -1,5 +1,3 @@
-function main(splash)
-    splash.images_enabled = false
-    assert(splash:go(splash.args.url))
-    return {png=splash:png()}
-end
+splash.images_enabled = false
+assert(splash:go(splash.args.url))
+return {png=splash:png()}

--- a/splash/examples/element-screenshot.lua
+++ b/splash/examples/element-screenshot.lua
@@ -9,23 +9,25 @@ function pad(r, pad)
   return {r[1]-pad, r[2]-pad, r[3]+pad, r[4]+pad}
 end
 
--- this function returns element bounding box
-local get_bbox = splash:jsfunc([[
-  function(css) {
-    var el = document.querySelector(css);
-    var r = el.getBoundingClientRect();
-    return [r.left, r.top, r.right, r.bottom];
-  }
-]])
+function main(splash, args)
+  -- this function returns element bounding box
+  local get_bbox = splash:jsfunc([[
+    function(css) {
+      var el = document.querySelector(css);
+      var r = el.getBoundingClientRect();
+      return [r.left, r.top, r.right, r.bottom];
+    }
+  ]])
 
--- main script
-assert(splash:go(splash.args.url))
-assert(splash:wait(0.5))
+  -- main script
+  assert(splash:go(splash.args.url))
+  assert(splash:wait(0.5))
 
--- don't crop image by a viewport
-splash:set_viewport_full()
+  -- don't crop image by a viewport
+  splash:set_viewport_full()
 
--- let's get a screenshot of a first <a>
--- element on a page, with extra 32px around it
-local region = pad(get_bbox("a"), 32)
-return splash:png{region=region}
+  -- let's get a screenshot of a first <a>
+  -- element on a page, with extra 32px around it
+  local region = pad(get_bbox("a"), 32)
+  return splash:png{region=region}
+end

--- a/splash/examples/element-screenshot.lua
+++ b/splash/examples/element-screenshot.lua
@@ -1,28 +1,31 @@
+-- This in an example of how to use lower-level
+-- Splash functions to get element screenshot.
+--
+-- In practice use splash:select("a"):png{pad=32}.
+
+
 -- this function adds padding around region
 function pad(r, pad)
   return {r[1]-pad, r[2]-pad, r[3]+pad, r[4]+pad}
 end
 
+-- this function returns element bounding box
+local get_bbox = splash:jsfunc([[
+  function(css) {
+    var el = document.querySelector(css);
+    var r = el.getBoundingClientRect();
+    return [r.left, r.top, r.right, r.bottom];
+  }
+]])
+
 -- main script
-function main(splash)
+assert(splash:go(splash.args.url))
+assert(splash:wait(0.5))
 
-  -- this function returns element bounding box
-  local get_bbox = splash:jsfunc([[
-    function(css) {
-      var el = document.querySelector(css);
-      var r = el.getBoundingClientRect();
-      return [r.left, r.top, r.right, r.bottom];
-    }
-  ]])
+-- don't crop image by a viewport
+splash:set_viewport_full()
 
-  assert(splash:go(splash.args.url))
-  assert(splash:wait(0.5))
-  
-  -- don't crop image by a viewport
-  splash:set_viewport_full()  
-
-  -- let's get a screenshot of a first <a>
-  -- element on a page, with extra 32px around it
-  local region = pad(get_bbox("a"), 32)
-  return splash:png{region=region}
-end
+-- let's get a screenshot of a first <a>
+-- element on a page, with extra 32px around it
+local region = pad(get_bbox("a"), 32)
+return splash:png{region=region}

--- a/splash/examples/har.lua
+++ b/splash/examples/har.lua
@@ -1,6 +1,3 @@
-function main(splash)
-  local url = splash.args.url
-  assert(splash:go(url))
-  assert(splash:wait(0.5))
-  return splash:har()
-end
+assert(splash:go(args.url))
+assert(splash:wait(0.5))
+return splash:har()

--- a/splash/examples/har.lua
+++ b/splash/examples/har.lua
@@ -1,3 +1,5 @@
-assert(splash:go(args.url))
-assert(splash:wait(0.5))
-return splash:har()
+function main(splash, args)
+  assert(splash:go(args.url))
+  assert(splash:wait(0.5))
+  return splash:har()
+end

--- a/splash/examples/log-requests.lua
+++ b/splash/examples/log-requests.lua
@@ -1,9 +1,11 @@
 treat = require("treat")
 
-local urls = {}
-splash:on_request(function(request)
-  table.insert(urls, request.url)
-end)
+function main(splash, args)
+  local urls = {}
+  splash:on_request(function(request)
+    table.insert(urls, request.url)
+  end)
 
-assert(splash:go(splash.args.url))
-return treat.as_array(urls)
+  assert(splash:go(splash.args.url))
+  return treat.as_array(urls)
+end

--- a/splash/examples/log-requests.lua
+++ b/splash/examples/log-requests.lua
@@ -1,9 +1,9 @@
 treat = require("treat")
-function main(splash)
-    local urls = {}
-    splash:on_request(function(request)
-        table.insert(urls, request.url)
-    end)
-    assert(splash:go(splash.args.url))
-    return treat.as_array(urls)
-end
+
+local urls = {}
+splash:on_request(function(request)
+  table.insert(urls, request.url)
+end)
+
+assert(splash:go(splash.args.url))
+return treat.as_array(urls)

--- a/splash/examples/multiple-pages.lua
+++ b/splash/examples/multiple-pages.lua
@@ -4,25 +4,26 @@ treat = require("treat")
 -- with the page screenshoot, it's HTML contents
 -- and it's title.
 function page_info(splash, url)
-    local ok, msg = splash:go(url)
-    if not ok then
-        return {ok=false, reason=msg}
-    end
-    local res = {
-        html=splash:html(),
-        title=splash:evaljs('document.title'),
-        image=splash:png(),
-        ok=true,
-    }
-    return res
+  local ok, msg = splash:go(url)
+  if not ok then
+    return {ok=false, reason=msg}
+  end
+  local res = {
+    html=splash:html(),
+    title=splash:evaljs('document.title'),
+    image=splash:png(),
+    ok=true,
+  }
+  return res
 end
 
--- visit first 3 pages of hacker news
-local base = "https://news.ycombinator.com/news?p="
-local result = treat.as_array({})
-for i=1,3 do
+function main(splash, args)
+  -- visit first 3 pages of hacker news
+  local base = "https://news.ycombinator.com/news?p="
+  local result = treat.as_array({})
+  for i=1,3 do
     local url =  base .. i
     result[i] = page_info(splash, url)
+  end
+  return result
 end
-
-return result

--- a/splash/examples/multiple-pages.lua
+++ b/splash/examples/multiple-pages.lua
@@ -19,11 +19,10 @@ end
 
 -- visit first 3 pages of hacker news
 local base = "https://news.ycombinator.com/news?p="
-function main(splash)
-    local result = treat.as_array({})
-    for i=1,3 do
-        local url =  base .. i
-        result[i] = page_info(splash, url)
-    end
-    return result
+local result = treat.as_array({})
+for i=1,3 do
+    local url =  base .. i
+    result[i] = page_info(splash, url)
 end
+
+return result

--- a/splash/examples/phantomjs-follow.lua
+++ b/splash/examples/phantomjs-follow.lua
@@ -19,6 +19,8 @@ function follow(splash, user)
   if not ok then
     return "Can't get followers of " .. user .. ': ' .. msg
   end
+  -- in practice it is easier to use splash:select(...):text(); evaljs
+  -- is just to make example closer to PhantomJS
   return splash:evaljs([[
     document.querySelector('div.profile td.stat.stat-last div.statnum').innerText;
   ]]);
@@ -32,8 +34,4 @@ function process(splash, users)
   return result
 end
 
-function main(splash)
-  return {
-    users=process(splash, USERS),
-  }
-end
+return {users=process(splash, USERS)}

--- a/splash/examples/phantomjs-follow.lua
+++ b/splash/examples/phantomjs-follow.lua
@@ -34,4 +34,6 @@ function process(splash, users)
   return result
 end
 
-return {users=process(splash, USERS)}
+function main(splash, args)
+  return {users=process(splash, USERS)}
+end

--- a/splash/examples/preload-functions.lua
+++ b/splash/examples/preload-functions.lua
@@ -1,9 +1,8 @@
-function main(splash)
-    splash:autoload([[
-        function get_document_title(){
-           return document.title;
-        }
-    ]])
-    assert(splash:go(splash.args.url))
-    return splash:evaljs("get_document_title()")
-end
+splash:autoload([[
+  function get_document_title(){
+    return document.title;
+  }
+]])
+assert(splash:go(args.url))
+
+return splash:evaljs("get_document_title()")

--- a/splash/examples/preload-functions.lua
+++ b/splash/examples/preload-functions.lua
@@ -1,8 +1,10 @@
-splash:autoload([[
-  function get_document_title(){
-    return document.title;
-  }
-]])
-assert(splash:go(args.url))
+function main(splash, args)
+  splash:autoload([[
+    function get_document_title(){
+      return document.title;
+    }
+  ]])
+  assert(splash:go(args.url))
 
-return splash:evaljs("get_document_title()")
+  return splash:evaljs("get_document_title()")
+end

--- a/splash/examples/preload-jquery.lua
+++ b/splash/examples/preload-jquery.lua
@@ -1,5 +1,7 @@
-assert(splash:autoload("https://code.jquery.com/jquery-2.1.3.min.js"))
-assert(splash:go(splash.args.url))
-local version = splash:evaljs("$.fn.jquery")
+function main(splash, args)
+  assert(splash:autoload("https://code.jquery.com/jquery-2.1.3.min.js"))
+  assert(splash:go(splash.args.url))
+  local version = splash:evaljs("$.fn.jquery")
 
-return 'JQuery version: ' .. version
+  return 'JQuery version: ' .. version
+end

--- a/splash/examples/preload-jquery.lua
+++ b/splash/examples/preload-jquery.lua
@@ -1,6 +1,5 @@
-function main(splash)
-    assert(splash:autoload("https://code.jquery.com/jquery-2.1.3.min.js"))
-    assert(splash:go(splash.args.url))
-    local version = splash:evaljs("$.fn.jquery")
-    return 'JQuery version: ' .. version
-end
+assert(splash:autoload("https://code.jquery.com/jquery-2.1.3.min.js"))
+assert(splash:go(splash.args.url))
+local version = splash:evaljs("$.fn.jquery")
+
+return 'JQuery version: ' .. version

--- a/splash/examples/render-png.lua
+++ b/splash/examples/render-png.lua
@@ -1,8 +1,8 @@
--- A simplistic implementation of render.png endpoint
-function main(splash, args)
-   assert(splash:go(args.url))
-   return splash:png{
-      width=args.width,
-      height=args.height
-   }
-end
+-- A simplistic implementation of render.png
+-- endpoint.
+assert(splash:go(args.url))
+
+return splash:png{
+  width=args.width,
+  height=args.height
+}

--- a/splash/examples/render-png.lua
+++ b/splash/examples/render-png.lua
@@ -1,8 +1,10 @@
 -- A simplistic implementation of render.png
 -- endpoint.
-assert(splash:go(args.url))
+function main(splash, args)
+  assert(splash:go(args.url))
 
-return splash:png{
-  width=args.width,
-  height=args.height
-}
+  return splash:png{
+    width=args.width,
+    height=args.height
+  }
+end

--- a/splash/examples/return-title.lua
+++ b/splash/examples/return-title.lua
@@ -1,5 +1,6 @@
-splash:go("http://example.com")
-splash:wait(0.5)
-local title = splash:evaljs("document.title")
-
-return {title=title}
+function main(splash, args)
+  splash:go("http://example.com")
+  splash:wait(0.5)
+  local title = splash:evaljs("document.title")
+  return {title=title}
+end

--- a/splash/examples/return-title.lua
+++ b/splash/examples/return-title.lua
@@ -1,8 +1,5 @@
+splash:go("http://example.com")
+splash:wait(0.5)
+local title = splash:evaljs("document.title")
 
-function main(splash)
-    splash:go("http://example.com")
-    splash:wait(0.5)
-    local title = splash:evaljs("document.title")
-    return {title=title}
-end
-
+return {title=title}

--- a/splash/examples/run-js.lua
+++ b/splash/examples/run-js.lua
@@ -1,8 +1,6 @@
-function main(splash)
-  assert(splash:go("https://news.ycombinator.com/"))
-  splash:runjs([[
-    document.querySelector('table')
-            .style.backgroundColor = "#fff";
-  ]])
-  return {png=splash:png()}
-end
+assert(splash:go("https://news.ycombinator.com/"))
+splash:runjs([[
+  document.querySelector('table')
+          .style.backgroundColor = "#fff";
+]])
+return {png=splash:png()}

--- a/splash/examples/run-js.lua
+++ b/splash/examples/run-js.lua
@@ -1,6 +1,8 @@
-assert(splash:go("https://news.ycombinator.com/"))
-splash:runjs([[
-  document.querySelector('table')
-          .style.backgroundColor = "#fff";
-]])
-return {png=splash:png()}
+function main(splash, args)
+  assert(splash:go("https://news.ycombinator.com/"))
+  splash:runjs([[
+    document.querySelector('table')
+            .style.backgroundColor = "#fff";
+  ]])
+  return {png=splash:png()}
+end

--- a/splash/examples/scroll.lua
+++ b/splash/examples/scroll.lua
@@ -1,5 +1,6 @@
-splash:go(args.url)
-local scroll_to = splash:jsfunc("window.scrollTo")
-scroll_to(0, 300)
-
-return {png=splash:png()}
+function main(splash, args)
+  splash:go(args.url)
+  local scroll_to = splash:jsfunc("window.scrollTo")
+  scroll_to(0, 300)
+  return {png=splash:png()}
+end

--- a/splash/examples/scroll.lua
+++ b/splash/examples/scroll.lua
@@ -1,6 +1,5 @@
-function main(splash, args)
-    splash:go(args.url)
-    local scroll_to = splash:jsfunc("window.scrollTo")
-    scroll_to(0, 300)
-    return {png=splash:png()}
-end
+splash:go(args.url)
+local scroll_to = splash:jsfunc("window.scrollTo")
+scroll_to(0, 300)
+
+return {png=splash:png()}

--- a/splash/examples/submit-search.lua
+++ b/splash/examples/submit-search.lua
@@ -28,11 +28,8 @@ function find_input(forms)
   return potential[1].form, potential[1].input
 end
 
-function main(splash)
-  splash.images_enabled = false
-  assert(splash:go(splash.args.url))
-  assert(splash:wait(1))
-
+-- find a form and submit "splash" to it
+function search_for_splash()
   local forms = splash:select_all('form')
 
   if #forms == 0 then
@@ -47,9 +44,13 @@ function main(splash)
 
   assert(input:send_keys('splash'))
   assert(splash:wait(0))
-
   assert(form:submit())
-  assert(splash:wait(1))
-
-  return splash:png()
 end
+
+-- main rendering script
+assert(splash:go(args.url))
+assert(splash:wait(1))
+search_for_splash()
+assert(splash:wait(3))
+
+return splash:png()

--- a/splash/examples/submit-search.lua
+++ b/splash/examples/submit-search.lua
@@ -28,29 +28,31 @@ function find_input(forms)
   return potential[1].form, potential[1].input
 end
 
--- find a form and submit "splash" to it
-function search_for_splash()
-  local forms = splash:select_all('form')
+function main(splash, args)
+  -- find a form and submit "splash" to it
+  local function search_for_splash()
+    local forms = splash:select_all('form')
 
-  if #forms == 0 then
-    error('no search form is found')
+    if #forms == 0 then
+      error('no search form is found')
+    end
+
+    local form, input = find_input(forms)
+
+    if not input then
+      error('no search form is found')
+    end
+
+    assert(input:send_keys('splash'))
+    assert(splash:wait(0))
+    assert(form:submit())
   end
 
-  local form, input = find_input(forms)
+  -- main rendering script
+  assert(splash:go(args.url))
+  assert(splash:wait(1))
+  search_for_splash()
+  assert(splash:wait(3))
 
-  if not input then
-    error('no search form is found')
-  end
-
-  assert(input:send_keys('splash'))
-  assert(splash:wait(0))
-  assert(form:submit())
+  return splash:png()
 end
-
--- main rendering script
-assert(splash:go(args.url))
-assert(splash:wait(1))
-search_for_splash()
-assert(splash:wait(3))
-
-return splash:png()

--- a/splash/examples/wait-for-element.lua
+++ b/splash/examples/wait-for-element.lua
@@ -26,7 +26,8 @@ function wait_for_element(splash, css, maxwait)
   ]], css, maxwait))
 end
 
--- main rendering script
-splash:go("http://scrapinghub.com")
-wait_for_element(splash, "#foo")
-return {png=splash:png()}
+function main(splash, args)
+  splash:go("http://scrapinghub.com")
+  wait_for_element(splash, "#foo")
+  return {png=splash:png()}
+end

--- a/splash/examples/wait-for-element.lua
+++ b/splash/examples/wait-for-element.lua
@@ -26,8 +26,7 @@ function wait_for_element(splash, css, maxwait)
   ]], css, maxwait))
 end
 
-function main(splash)
-    splash:go("http://scrapinghub.com")
-    wait_for_element(splash, "#foo")
-    return {png=splash:png()}
-end
+-- main rendering script
+splash:go("http://scrapinghub.com")
+wait_for_element(splash, "#foo")
+return {png=splash:png()}

--- a/splash/examples/with-timeout.lua
+++ b/splash/examples/with-timeout.lua
@@ -1,15 +1,16 @@
-local ok, result = splash:with_timeout(function()
-  -- try commenting out splash:wait(3)
-  splash:wait(3)
-  assert(splash:go(args.url))
-end, 2)
+function main(splash, args)
+  local ok, result = splash:with_timeout(function()
+    -- try commenting out splash:wait(3)
+    splash:wait(3)
+    assert(splash:go(args.url))
+  end, 2)
 
-if not ok then
-  if result == "timeout_over" then
-    return "Cannot navigate to the url within 2 seconds"
-  else
-    return result
+  if not ok then
+    if result == "timeout_over" then
+      return "Cannot navigate to the url within 2 seconds"
+    else
+      return result
+    end
   end
+  return "Navigated to the url within 2 seconds"
 end
-
-return "Navigated to the url within 2 seconds"

--- a/splash/examples/with-timeout.lua
+++ b/splash/examples/with-timeout.lua
@@ -1,16 +1,15 @@
-function main(splash, args)
-  local ok, result = splash:with_timeout(function()
-    splash:wait(3)
-    assert(splash:go(args.url))
-  end, 2)
+local ok, result = splash:with_timeout(function()
+  -- try commenting out splash:wait(3)
+  splash:wait(3)
+  assert(splash:go(args.url))
+end, 2)
 
-  if not ok then
-    if result == "timeout_over" then
-      return "Cannot navigate to the url within 2 seconds"
-    else
-      return result
-    end
+if not ok then
+  if result == "timeout_over" then
+    return "Cannot navigate to the url within 2 seconds"
+  else
+    return result
   end
-
-  return "Navigated to the url within 2 seconds"
 end
+
+return "Navigated to the url within 2 seconds"

--- a/splash/resources.py
+++ b/splash/resources.py
@@ -625,13 +625,15 @@ class Root(Resource):
 
     def get_example_script(self):
         return """
-assert(splash:go(args.url))
-assert(splash:wait(0.5))
-return {
-  html = splash:html(),
-  png = splash:png(),
-  har = splash:har(),
-}
+function main(splash, args)
+  assert(splash:go(args.url))
+  assert(splash:wait(0.5))
+  return {
+    html = splash:html(),
+    png = splash:png(),
+    har = splash:har(),
+  }
+end
 """.strip()
 
     def render_GET(self, request):
@@ -734,7 +736,7 @@ return {
             version=splash.__version__,
             theme=BOOTSTRAP_THEME,
             options=safe_json({
-                "endpoint": "run" if self.lua_enabled else "render.json",
+                "endpoint": "execute" if self.lua_enabled else "render.json",
                 "lua_enabled": self.lua_enabled,
                 "example_script": self.get_example_script(),
             }),

--- a/splash/resources.py
+++ b/splash/resources.py
@@ -546,7 +546,7 @@ class DemoUI(_ValidatingResource):
             harviewer_path=HARVIEWER_PATH,
             options=safe_json({
                 "params": params,
-                "endpoint": "run" if self.lua_enabled else "render.json",
+                "endpoint": "execute" if self.lua_enabled else "render.json",
                 "harviewer_path": HARVIEWER_PATH,
                 "lua_enabled": self.lua_enabled,
             }),

--- a/splash/resources.py
+++ b/splash/resources.py
@@ -271,12 +271,14 @@ class ExecuteLuaScriptResource(BaseRenderResource):
                  max_timeout,
                  argument_cache,
                  strict,
+                 implicit_main,
                  ):
         BaseRenderResource.__init__(self, pool, max_timeout, argument_cache)
         self.sandboxed = sandboxed
         self.lua_package_path = lua_package_path
         self.lua_sandbox_allowed_modules = lua_sandbox_allowed_modules
         self.strict = strict
+        self.implicit_main = implicit_main
 
     def _get_render(self, request, options):
         params = dict(
@@ -286,6 +288,7 @@ class ExecuteLuaScriptResource(BaseRenderResource):
             lua_package_path=self.lua_package_path,
             lua_sandbox_allowed_modules=self.lua_sandbox_allowed_modules,
             strict=self.strict,
+            implicit_main=self.implicit_main,
         )
         return self.pool.render(LuaRender, options, **params)
 
@@ -543,7 +546,7 @@ class DemoUI(_ValidatingResource):
             harviewer_path=HARVIEWER_PATH,
             options=safe_json({
                 "params": params,
-                "endpoint": "execute" if self.lua_enabled else "render.json",
+                "endpoint": "run" if self.lua_enabled else "render.json",
                 "harviewer_path": HARVIEWER_PATH,
                 "lua_enabled": self.lua_enabled,
             }),
@@ -582,7 +585,7 @@ class Root(Resource):
         self.putChild(b"debug", DebugResource(pool, self.argument_cache, warn=True))
 
         if self.lua_enabled and ExecuteLuaScriptResource is not None:
-            self.putChild(b"execute", ExecuteLuaScriptResource(
+            lua_kwargs = dict(
                 pool=pool,
                 sandboxed=lua_sandbox_enabled,
                 lua_package_path=lua_package_path,
@@ -590,7 +593,11 @@ class Root(Resource):
                 max_timeout=max_timeout,
                 argument_cache=self.argument_cache,
                 strict=strict_lua_runner,
-            ))
+            )
+            self.putChild(b"execute", ExecuteLuaScriptResource(
+                implicit_main=False, **lua_kwargs))
+            self.putChild(b"run", ExecuteLuaScriptResource(
+                implicit_main=True, **lua_kwargs))
 
         if self.ui_enabled:
             root = os.path.dirname(__file__)
@@ -618,16 +625,13 @@ class Root(Resource):
 
     def get_example_script(self):
         return """
-function main(splash)
-  local url = splash.args.url
-  assert(splash:go(url))
-  assert(splash:wait(0.5))
-  return {
-    html = splash:html(),
-    png = splash:png(),
-    har = splash:har(),
-  }
-end
+assert(splash:go(args.url))
+assert(splash:wait(0.5))
+return {
+  html = splash:html(),
+  png = splash:png(),
+  har = splash:har(),
+}
 """.strip()
 
     def render_GET(self, request):
@@ -730,7 +734,7 @@ end
             version=splash.__version__,
             theme=BOOTSTRAP_THEME,
             options=safe_json({
-                "endpoint": "execute" if self.lua_enabled else "render.json",
+                "endpoint": "run" if self.lua_enabled else "render.json",
                 "lua_enabled": self.lua_enabled,
                 "example_script": self.get_example_script(),
             }),

--- a/splash/tests/test_run.py
+++ b/splash/tests/test_run.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from .test_execute import BaseLuaRenderTest
+
+class BaseRunTest(BaseLuaRenderTest):
+    endpoint = 'run'
+
+
+class RunTest(BaseRunTest):
+    def test_render(self):
+        resp = self.request_lua("splash:go(args.url); return splash:html()",
+                                {'url': self.mockurl('jsrender')})
+        self.assertStatusCode(resp, 200)
+        self.assertNotIn("Before", resp.text)
+        self.assertIn("After", resp.text)

--- a/splash/ui/main.js
+++ b/splash/ui/main.js
@@ -344,7 +344,7 @@ if(splash.params) {
             }
         }
     };
-    xhr.open('POST', splash.lua_enabled ? '/execute' : '/render.json');
+    xhr.open('POST', splash.lua_enabled ? '/run' : '/render.json');
     xhr.setRequestHeader('content-type', 'application/json');
     xhr.responseType = 'blob'; // Need blob in case an image is returned directly
     xhr.send(JSON.stringify(params));

--- a/splash/ui/main.js
+++ b/splash/ui/main.js
@@ -344,7 +344,7 @@ if(splash.params) {
             }
         }
     };
-    xhr.open('POST', splash.lua_enabled ? '/run' : '/render.json');
+    xhr.open('POST', splash.lua_enabled ? '/execute' : '/render.json');
     xhr.setRequestHeader('content-type', 'application/json');
     xhr.responseType = 'blob'; // Need blob in case an image is returned directly
     xhr.send(JSON.stringify(params));


### PR DESCRIPTION
I think it is good to add "implicit main" mode to Splash.

1. Writing ``function main(splash, args) ... end`` is annoying for short scripts.
2. Utility functions often need `splash` variable. It means they must be either inside ``main`` function, or be called with `splash` argument, or extend Splash object (which is not possible for sripts submitted via HTTP). With "implicit main" all code is inside `main` function, so `splash` is a global variable. It means it becomes easier to build a script by concatenating multiple parts; this can be seen as a poor man's import system for HTTP API - just concatenate Lua libraries, and add a rendering script to the end.