### PR TITLE
Docs : missing /tmp/script.qs file in manual install

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -54,7 +54,7 @@ Ubuntu 16.04 (manual way)
 2. Install dependencies::
 
       $ cd splash/dockerfiles/splash
-
+      $ sudo cp ./qt-installer-noninteractive.qs /tmp/script.qs
       $ sudo ./provision.sh \
                  prepare_install \
                  install_msfonts \


### PR DESCRIPTION
I received the error '/tmp/script.qs file does not exist' when installing Splash manually and running ./provision.sh install_official_qt command