### PR TITLE
fix splash:runjs wrapping

### DIFF
--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -763,7 +763,7 @@ class BrowserTab(QObject):
         # a result - it could be costly. So the original JS code
         # is adjusted to make sure it doesn't return anything.
         self.evaljs(
-            js_source="%s;undefined" % js_source,
+            js_source="%s\n;undefined" % js_source,
             handle_errors=handle_errors,
             result_protection=False,
             dom_elements=False,

--- a/splash/browser_tab.py
+++ b/splash/browser_tab.py
@@ -3,6 +3,7 @@ import base64
 import functools
 import os
 import weakref
+import traceback
 
 from PyQt5.QtCore import (QObject, QSize, Qt, QTimer, pyqtSlot, QEvent,
                           QPointF, QPoint, pyqtSignal)
@@ -660,13 +661,18 @@ class BrowserTab(QObject):
     def _on_javascript_window_object_cleared(self):
         self._js_storage_initiated = False
 
-        for script in self._autoload_scripts:
+        for idx, script in enumerate(self._autoload_scripts):
             # XXX: handle_errors=False is used to execute autoload scripts
             # in a global context (not inside a closure).
             # One difference is how are `function foo(){}` statements handled:
             # if executed globally, `foo` becomes an attribute of window;
             # if executed in a closure, `foo` is a name local to this closure.
-            self.runjs(script, handle_errors=False)
+            try:
+                self.runjs(script, handle_errors=False)
+            except Exception as e:
+                msg = "Error in autoload script #{}:".format(idx, e)
+                self.logger.log(msg, min_level=1)
+                self.logger.log(traceback.format_exc(), min_level=1)
 
     def http_get(self, url, callback, headers=None, follow_redirects=True):
         """

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -1047,6 +1047,16 @@ class RunjsTest(BaseLuaRenderTest):
         err = resp.json()['err']
         self.assertEqual(err, 'JS error: "ReferenceError: Can\'t find variable: y"')
 
+    def test_runjs_nowrap(self):
+        resp = self.request_lua("""
+        function main(splash)
+            local res, err = splash:runjs("true;//")
+            return {res=res, err=err}
+        end
+        """)
+        self.assertStatusCode(resp, 200)
+        self.assertEqual(resp.json(), {"res": True})
+
     def test_runjs_assert(self):
         resp = self.request_lua("""
         function main(splash)

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -2580,6 +2580,16 @@ class AutoloadTest(BaseLuaRenderTest):
         self.assertNotIn("ok", resp.json())
         self.assertIn("404", resp.json()["reason"])
 
+    def test_autoload_bad_script(self):
+        resp = self.request_lua("""
+        function main(splash)
+            local ok, reason = splash:autoload("throw 123;")
+            assert(splash:go(splash.args.url))
+            return {ok=ok, reason=reason}
+        end
+        """, {"url": self.mockurl("getrequest")})
+        self.assertStatusCode(resp, 200)
+
     def test_noargs(self):
         resp = self.request_lua("""
         function main(splash)


### PR DESCRIPTION
This is a traceback I was getting:

```
Traceback (most recent call last):
  File "/app/splash/browser_tab.py", line 669, in _on_javascript_window_object_cleared
    self.runjs(script, handle_errors=False)
  File "/app/splash/browser_tab.py", line 763, in runjs
    dom_elements=False,
  File "/app/splash/browser_tab.py", line 750, in evaljs
    return self._process_js_result(result, allow_dom=dom_elements)
  File "/app/splash/browser_tab.py", line 611, in _process_js_result
    raise ValueError("Invalid input object: %r" % obj)
ValueError: Invalid input object: True
```

It happened because splash:runjs doesn't prevent return value properly. This is fixed, and Splash is also made more robust agains splash:runjs exceptions.