### PR TITLE
Example script for scraping specific response body

### DIFF
--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -2222,6 +2222,28 @@ By default, this ``response`` object doesn't have :ref:`splash-response-body`
 attribute. To enable it, use :ref:`splash-response-body-enabled` option
 or :ref:`splash-request-enable-response-body` method.
 
+Example 1 - to log a response body only when requested url match a desired pattern:
+
+.. code-block:: lua
+
+    treat = require('treat')
+    function main(splash, args)
+        splash.resource_timeout = 10.0
+        splash:on_request(function(request)
+            if string.find(request.url, "hello") ~= nil then
+                request.enable_response_body()
+            end
+        end)
+        splash:on_response(function(response)
+            if string.find(response.url, "hello") ~= nil then
+                s, content_type = treat.as_string(response.body)
+            end
+        end)
+    
+        assert(splash:go(splash.args.url))
+        return s
+    end
+
 .. note::
 
     :ref:`splash-on-response` doesn't support named arguments.


### PR DESCRIPTION
Hi, I am first time splash and Lua user. I benefited from examples in the reference. But there were no reference for the on_response callback. I'd like to share my example.

It is useful to record certain response body only when requested url match a pattern.

Thank you for considering. Feel free to revise it.

Best, Yi