### PR TITLE
Add callback for requests locked by lock_navigation

### DIFF
--- a/docs/scripting-overview.rst
+++ b/docs/scripting-overview.rst
@@ -35,6 +35,8 @@ Navigation
   to the browser;
 * :ref:`splash-lock-navigation` and :ref:`splash-unlock-navigation` -
   lock/unlock navigation;
+* :ref:`splash-on-navigation-locked` allows to inspect requests
+  discarded after navigation was locked;
 * :ref:`splash-set-user-agent` allows to change User-Agent header used
   for requests;
 * :ref:`splash-set-custom-headers` allows to set default HTTP headers

--- a/docs/scripting-ref.rst
+++ b/docs/scripting-ref.rst
@@ -2783,3 +2783,49 @@ Example: select all ``<img />`` elements and get their ``src`` attributes
 
         return treat.as_array(srcs)
     end
+
+
+.. _splash-on-navigation-locked:
+
+splash:on_navigation_locked
+---------------------------
+
+Register a function to be called before a request is discarded when navigation is locked.
+
+**Signature:** ``splash:on_navigation_locked(callback)``
+
+**Parameters:**
+
+* callback - Lua function to call before a request is discarded.
+
+**Returns:** nil.
+
+**Async:** no.
+
+:ref:`splash-on-navigation-locked` callback receives a single ``request`` argument
+(a :ref:`splash-request`).
+
+To get information about a request use request
+:ref:`attributes <splash-request-attributes>`;
+
+A callback passed to :ref:`splash-on-navigation-locked` can't call Splash
+async methods like :ref:`splash-wait` or :ref:`splash-go`.
+
+Example 1 - log all URLs discarded using :ref:`splash-request-url` attribute:
+
+.. literalinclude:: ../splash/examples/log-locked-requests.lua
+   :language: lua
+
+
+.. _splash-on-navigation-locked-reset:
+
+splash:on_navigation_locked_reset
+---------------------------------
+
+Remove all callbacks registered by :ref:`splash-on-navigation-locked`.
+
+**Signature:** ``splash:on_navigation_locked_reset()``
+
+**Returns:** nil
+
+**Async:** no.

--- a/splash/examples/log-locked-requests.lua
+++ b/splash/examples/log-locked-requests.lua
@@ -1,0 +1,13 @@
+treat = require("treat")
+
+function main(splash, args)
+  local urls = {}
+  splash:on_navigation_locked(function(request)
+    table.insert(urls, request.url)
+  end)
+
+  assert(splash:go(splash.args.url))
+  splash:lock_navigation()
+  splash:select("a"):mouse_click()
+  return treat.as_array(urls)
+end

--- a/splash/kernel/inspections/splash-auto.json
+++ b/splash/kernel/inspections/splash-auto.json
@@ -691,5 +691,27 @@
     "async": "no.",
     "details": "This method differs from :ref:`splash-select` by returning the *all*\nelements in a table that match the specified selector.\n\nIf no elements can be found using the specified selector ``{}`` is\nreturned. If the selector is not a valid CSS selector an error is raised.\n\nExample: select all ``<img />`` elements and get their ``src`` attributes\n\n.. code-block:: lua\n\n    local treat = require('treat')\n\n    function main(splash)\n        assert(splash:go(splash.args.url))\n        assert(splash:wait(0.5))\n\n        local imgs = splash:select_all('img')\n        local srcs = {}\n\n        for _, img in ipairs(imgs) do\n          srcs[#srcs+1] = img.node.attributes.src\n        end\n\n        return treat.as_array(srcs)\n    end",
     "params": "* selector - valid CSS selector"
+  },
+  "splash:on_navigation_locked": {
+    "name": "on_navigation_locked",
+    "header": "splash:on_navigation_locked",
+    "content": "Register a function to be called before a request is discarded when navigation is locked.\n\n**Signature:** ``splash:on_navigation_locked(callback)``\n\n**Parameters:**\n\n* callback - Lua function to call before a request is discarded.\n\n**Returns:** nil.\n\n**Async:** no.\n\n:ref:`splash-on-navigation-locked` callback receives a single ``request`` argument\n(a :ref:`splash-request`).\n\nTo get information about a request use request\n:ref:`attributes <splash-request-attributes>`;\n\nA callback passed to :ref:`splash-on-navigation-locked` can't call Splash\nasync methods like :ref:`splash-wait` or :ref:`splash-go`.\n\nExample 1 - log all URLs discarded using :ref:`splash-request-url` attribute:\n\ntreat = require(\"treat\")\n\nfunction main(splash, args)\n  local urls = {}\n  splash:on_navigation_locked(function(request)\n    table.insert(urls, request.url)\n  end)\n\n  assert(splash:go(splash.args.url))\n  splash:lock_navigation()\n  splash:select(\"a\"):mouse_click()\n  return treat.as_array(urls)\nend",
+    "short": "Register a function to be called before a request is discarded when navigation is locked.",
+    "signature": "splash:on_navigation_locked(callback)",
+    "returns": "nil.",
+    "async": "no.",
+    "details": ":ref:`splash-on-navigation-locked` callback receives a single ``request`` argument\n(a :ref:`splash-request`).\n\nTo get information about a request use request\n:ref:`attributes <splash-request-attributes>`;\n\nA callback passed to :ref:`splash-on-navigation-locked` can't call Splash\nasync methods like :ref:`splash-wait` or :ref:`splash-go`.\n\nExample 1 - log all URLs discarded using :ref:`splash-request-url` attribute:\n\ntreat = require(\"treat\")\n\nfunction main(splash, args)\n  local urls = {}\n  splash:on_navigation_locked(function(request)\n    table.insert(urls, request.url)\n  end)\n\n  assert(splash:go(splash.args.url))\n  splash:lock_navigation()\n  splash:select(\"a\"):mouse_click()\n  return treat.as_array(urls)\nend",
+    "params": "* callback - Lua function to call before a request is discarded."
+  },
+  "splash:on_navigation_locked_reset": {
+    "name": "on_navigation_locked_reset",
+    "header": "splash:on_navigation_locked_reset",
+    "content": "Remove all callbacks registered by :ref:`splash-on-navigation-locked`.\n\n**Signature:** ``splash:on_navigation_locked_reset()``\n\n**Returns:** nil\n\n**Async:** no.",
+    "short": "Remove all callbacks registered by :ref:`splash-on-navigation-locked`.",
+    "signature": "splash:on_navigation_locked_reset()",
+    "returns": "nil",
+    "async": null,
+    "details": "**Async:** no.",
+    "params": null
   }
 }

--- a/splash/lua_modules/splash.lua
+++ b/splash/lua_modules/splash.lua
@@ -61,6 +61,16 @@ function Splash:on_response(cb)
   end)
 end
 
+function Splash:on_navigation_locked(cb)
+  if type(cb) ~= 'function' then
+    error("splash:on_navigation_locked callback is not a function", 2)
+  end
+  self:_on_navigation_locked(function(py_request)
+    local req = Request._create(py_request)
+    return cb(req)
+  end)
+end
+
 
 --
 -- Timer Lua wrapper

--- a/splash/network_manager.py
+++ b/splash/network_manager.py
@@ -389,18 +389,9 @@ class ProxiedQNetworkAccessManager(QNetworkAccessManager):
         return self._get_webpage_attribute(request, 'render_options')
 
     def _run_webpage_callbacks(self, request, event_name, *args):
-        callbacks = self._get_webpage_attribute(request, "callbacks")
-        if not callbacks:
-            return
-        for cb in callbacks.get(event_name, []):
-            try:
-                cb(*args)
-            except:
-                # TODO unhandled exceptions in lua callbacks
-                # should we raise errors here?
-                # https://github.com/scrapinghub/splash/issues/161
-                self.log("error in %s callback" % event_name, min_level=1)
-                self.log(traceback.format_exc(), min_level=1, format_msg=False)
+        run_callbacks = self._get_webpage_attribute(request, "run_callbacks")
+        if run_callbacks:
+            run_callbacks(event_name, *args)
 
     def log(self, msg, reply=None, min_level=2, format_msg=True):
         if self.verbosity < min_level:

--- a/splash/qtrender_lua.py
+++ b/splash/qtrender_lua.py
@@ -1221,6 +1221,21 @@ class Splash(BaseExposedObject):
                 'walltime': time.time()}
 
     @command(sets_callback=True, decode_arguments=False)
+    def _on_navigation_locked(self, callback):
+        """
+        Register a Lua callback to be called when navigation happens but it is locked.
+        """
+        def _callback(request):
+            if self.destroyed:
+                return
+            exceptions = StoredExceptions()  # FIXME: exceptions are discarded
+            req = _ExposedBoundRequest(self.lua, exceptions, request, None, None)
+            with req.allowed():
+                callback(req)
+        self.tab.register_callback("on_navigation_locked", _callback)
+        return True
+
+    @command(sets_callback=True, decode_arguments=False)
     def _on_request(self, callback):
         """
         Register a Lua callback to be called when a resource is requested.
@@ -1345,6 +1360,10 @@ class Splash(BaseExposedObject):
     @command()
     def on_response_headers_reset(self):
         self.tab.clear_callbacks("on_response_headers")
+
+    @command()
+    def on_navigation_locked_reset(self):
+        self.tab.clear_callbacks("on_navigation_locked")
 
     @command()
     def get_version(self):


### PR DESCRIPTION
The `on_navigation_locked` callback proposed here is useful to track requests even after calling `splash:lock_navigation()`.