### PR TITLE
[MRG+1] Added option to disable the webkit in-memory and network caches

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -343,6 +343,19 @@ Please refer to `this great answer from kmike on reddit.
 
 .. _why-lua:
 
+Why are CSS styling and images missing from the .har archive?
+-------------------------------------------------------------
+
+Webkit has an in-memory cache (also `called page-cache <https://webkit.org/blog/427/webkit-page-cache-i-the-basics/>`)
+and a `network cache <http://doc.qt.io/qt-5/qnetworkrequest.html#CacheLoadControl-enum>`. 
+
+If you tell splash to load two pages that share some common resources,
+the second page's .har file will not contain the shared resources because
+they were cached through the page cache.
+
+If you want the .har file to contain all the resources for that page,
+run splasy with the command-line option ``--disable-browser-caches``.
+
 Why does Splash use Lua for scripting, not Python or JavaScript?
 ----------------------------------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -341,7 +341,7 @@ Why was Splash created in the first place?
 Please refer to `this great answer from kmike on reddit.
 <https://www.reddit.com/r/Python/comments/2xp5mr/handling_javascript_in_scrapy_with_splash/cp2vgd6>`__
 
-.. _why-lua:
+.. _why-css-images:
 
 Why are CSS styling and images missing from the .har archive?
 -------------------------------------------------------------
@@ -354,7 +354,9 @@ the second page's .har file will not contain the shared resources because
 they were cached through the page cache.
 
 If you want the .har file to contain all the resources for that page,
-run splasy with the command-line option ``--disable-browser-caches``.
+run splash with the command-line option ``--disable-browser-caches``.
+
+.. _why-lua:
 
 Why does Splash use Lua for scripting, not Python or JavaScript?
 ----------------------------------------------------------------

--- a/splash/server.py
+++ b/splash/server.py
@@ -355,7 +355,7 @@ def _set_global_render_settings(js_disable_cross_domain_access, private_mode, di
     if disable_browser_caches is True:
         # disables the page cache (also known as the in-memory webkit cache)
         # see https://webkit.org/blog/427/webkit-page-cache-i-the-basics/
-        settings.setObjectCacheCapacities(0,0,0)
+        settings.setObjectCacheCapacities(0, 0, 0)
         settings.setMaximumPagesInCache(0)
 
 

--- a/splash/server.py
+++ b/splash/server.py
@@ -51,6 +51,8 @@ def parse_opts(jupyter=False, argv=sys.argv):
         help="disable Xvfb auto start")
     op.add_option("--disable-lua-sandbox", action="store_true", default=False,
         help="disable Lua sandbox")
+    op.add_option("--disable-browser-caches", action="store_true", default=False,
+        help="disables in-memory and network caches used by webkit")
     op.add_option("--lua-package-path", default="",
         help="semicolon-separated places to add to Lua package.path. "
              "Each place can have a ? in it that's replaced with the module name.")
@@ -178,6 +180,7 @@ def splash_server(portnum, ip, slots, network_manager_factory, max_timeout,
                   lua_sandbox_allowed_modules=(),
                   strict_lua_runner=False,
                   argument_cache_max_entries=None,
+                  disable_browser_caches=False,
                   verbosity=None):
     from twisted.internet import reactor
     from twisted.web.server import Site
@@ -277,16 +280,19 @@ def default_splash_server(portnum, ip, max_timeout, slots=None,
                           strict_lua_runner=False,
                           argument_cache_max_entries=None,
                           verbosity=None,
-                          server_factory=splash_server):
+                          server_factory=splash_server,
+                          disable_browser_caches=False,
+                          ):
     from splash import network_manager
     network_manager_factory = network_manager.NetworkManagerFactory(
         filters_path=filters_path,
         verbosity=verbosity,
         allowed_schemes=allowed_schemes,
+        disable_browser_caches=disable_browser_caches,
     )
     splash_proxy_factory_cls = _default_proxy_factory(proxy_profiles_path)
     js_profiles_path = _check_js_profiles_path(js_profiles_path)
-    _set_global_render_settings(js_disable_cross_domain_access, private_mode)
+    _set_global_render_settings(js_disable_cross_domain_access, private_mode, disable_browser_caches)
     return server_factory(
         portnum=portnum,
         ip=ip,
@@ -300,6 +306,7 @@ def default_splash_server(portnum, ip, max_timeout, slots=None,
         lua_package_path=lua_package_path,
         lua_sandbox_allowed_modules=lua_sandbox_allowed_modules,
         strict_lua_runner=strict_lua_runner,
+        disable_browser_caches=disable_browser_caches,
         verbosity=verbosity,
         max_timeout=max_timeout,
         argument_cache_max_entries=argument_cache_max_entries,
@@ -331,7 +338,7 @@ def _check_js_profiles_path(js_profiles_path):
     return js_profiles_path
 
 
-def _set_global_render_settings(js_disable_cross_domain_access, private_mode):
+def _set_global_render_settings(js_disable_cross_domain_access, private_mode, disable_browser_caches):
     from PyQt5.QtWebKit import QWebSecurityOrigin, QWebSettings
 
     if js_disable_cross_domain_access is False:
@@ -344,6 +351,12 @@ def _set_global_render_settings(js_disable_cross_domain_access, private_mode):
     settings = QWebSettings.globalSettings()
     settings.setAttribute(QWebSettings.PrivateBrowsingEnabled, private_mode)
     settings.setAttribute(QWebSettings.LocalStorageEnabled, not private_mode)
+
+    if disable_browser_caches is True:
+        # disables the page cache (also known as the in-memory webkit cache)
+        # see https://webkit.org/blog/427/webkit-page-cache-i-the-basics/
+        settings.setObjectCacheCapacities(0,0,0)
+        settings.setMaximumPagesInCache(0)
 
 
 def main(jupyter=False, argv=sys.argv, server_factory=splash_server):
@@ -388,6 +401,7 @@ def main(jupyter=False, argv=sys.argv, server_factory=splash_server):
             max_timeout=opts.max_timeout,
             argument_cache_max_entries=opts.argument_cache_max_entries,
             server_factory=server_factory,
+            disable_browser_caches=opts.disable_browser_caches
         )
         signal.signal(signal.SIGUSR1, lambda s, f: traceback.print_stack(f))
 

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -903,8 +903,8 @@ class Subresources(Resource):
 
 class SubresourcesWithCaching(Resource):
     """
-        Embedded css and image.
-        Allows caching of the css and the image by setting the Cache-Control header.
+        Embedded css.
+        Allows caching of the image by setting the Cache-Control header.
 
         Very similar to the /subresources/ endpoint.
     """
@@ -924,8 +924,7 @@ class SubresourcesWithCaching(Resource):
 
     @use_chunked_encoding
     def render_GET(self, request):
-        return ("""<html><head>
-            </head>
+        return ("""<html>
             <body>
             <img id="image" src="subresources-with-caching/img.gif"
                  onload="window.imageLoaded = true;"

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -901,6 +901,22 @@ class Subresources(Resource):
             return base64.decodebytes(b'R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=')
 
 
+class SubresourcesWithCaching(Subresources):
+    """ Embedded css and image """
+
+    @use_chunked_encoding
+    def render_GET(self, request):
+        return ("""<html><head>
+                <link rel="stylesheet" href="subresources-with-caching/style.css" />
+            </head>
+            <body>
+            <img id="image" src="subresources-with-caching/img.gif"
+                 onload="window.imageLoaded = true;"
+                 onerror="window.imageLoaded = false;"/>
+            </body>
+        </html>""").encode('utf-8')
+
+
 class SetHeadersResource(Resource):
 
     @use_chunked_encoding
@@ -1006,6 +1022,7 @@ class Root(Resource):
         self.putChild(b"very-long-green-page", VeryLongGreenPage())
         self.putChild(b"rgb-stripes", RgbStripesPage())
         self.putChild(b"subresources", Subresources())
+        self.putChild(b"subresources-with-caching", SubresourcesWithCaching())
         self.putChild(b"set-header", SetHeadersResource())
         self.putChild(b"echourl", EchoUrl())
         self.putChild(b"bad-content-type", InvalidContentTypeResource())

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -901,8 +901,37 @@ class Subresources(Resource):
             return base64.decodebytes(b'R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=')
 
 
-class SubresourcesWithCaching(Subresources):
-    """ Embedded css and image """
+class SubresourcesWithCaching(Resource):
+    """
+        Embedded css and image.
+        Allows caching of the css and the image by setting the Cache-Control header.
+
+        Very similar to the /subresources/ endpoint.
+    """
+
+    def getChild(self, name, request):
+        if name == b"style.css":
+            return self.StyleSheet()
+        if name == b"img.gif":
+            return self.Image()
+        return self
+
+    class StyleSheet(Resource):
+
+        @use_chunked_encoding
+        def render_GET(self, request):
+            request.setHeader(b"Content-Type", b"text/css; charset=utf-8")
+            request.setHeader(b"Cache-Control", b"public, max-age=999999, s-maxage=999999")
+            print("Request Style!")
+            return b"body { background-color: red; }"
+
+    class Image(Resource):
+
+        @use_chunked_encoding
+        def render_GET(self, request):
+            request.setHeader(b"Content-Type", b"image/gif")
+            request.setHeader(b"Cache-Control", b"public, max-age=999999, s-maxage=999999")
+            return base64.decodebytes(b'R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=')
 
     @use_chunked_encoding
     def render_GET(self, request):

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -910,20 +910,9 @@ class SubresourcesWithCaching(Resource):
     """
 
     def getChild(self, name, request):
-        if name == b"style.css":
-            return self.StyleSheet()
         if name == b"img.gif":
             return self.Image()
         return self
-
-    class StyleSheet(Resource):
-
-        @use_chunked_encoding
-        def render_GET(self, request):
-            request.setHeader(b"Content-Type", b"text/css; charset=utf-8")
-            request.setHeader(b"Cache-Control", b"public, max-age=999999, s-maxage=999999")
-            print("Request Style!")
-            return b"body { background-color: red; }"
 
     class Image(Resource):
 
@@ -936,7 +925,6 @@ class SubresourcesWithCaching(Resource):
     @use_chunked_encoding
     def render_GET(self, request):
         return ("""<html><head>
-                <link rel="stylesheet" href="subresources-with-caching/style.css" />
             </head>
             <body>
             <img id="image" src="subresources-with-caching/img.gif"

--- a/splash/tests/test_request_filters.py
+++ b/splash/tests/test_request_filters.py
@@ -180,37 +180,31 @@ class AllowedSchemesTest(BaseRenderTest):
             r = requests.get(render_url, params={'url': test_url, 'response_body': 1})
             self.assertStatusCode(r, 200)
             entry11 = self.findHAREntry(r.json(),r"^.*subresources-with-caching$")
-            entry12 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/style.css$")
-            entry13 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/img.gif$")
+            entry12 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/img.gif$")
 
             # 2nd page fetch
             r = requests.get(render_url, params={'url': test_url, 'response_body': 1})
             self.assertStatusCode(r, 200)
             entry21 = self.findHAREntry(r.json(),r"^.*subresources-with-caching$")
-            entry22 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/style.css$")
-            entry23 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/img.gif$")
+            entry22 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/img.gif$")
 
-            return [[entry11,entry12,entry13],[entry21,entry22,entry23]]
+            return [[entry11,entry12],[entry21,entry22]]
 
     # run just this test using
     # pytest -s --verbosity=6 ./splash/tests/test_request_filters.py -k test_disable_browser_caches
     def test_disable_browser_caches(self):
         # entries if run with caches enabled
-        # in this case we should have  [[content,content,content],[content,content,no content]]
+        # in this case we should have  [[content,content],[content,no content]]
         ce = self.run_with_extra_args([])
         self.assertIsNotNone(ce[0][0])
         self.assertIsNotNone(ce[0][1])
-        self.assertIsNotNone(ce[0][2])
         self.assertIsNotNone(ce[1][0])
-        self.assertIsNotNone(ce[1][1])
-        self.assertIsNone(ce[1][2])
+        self.assertIsNone(ce[1][1])
 
         # entries if run with caches disabled 
-        # in this case we should have  [[content,content,content],[content,content,content]]
+        # in this case we should have  [[content,content],[content,content]]
         cd = self.run_with_extra_args(['--disable-browser-caches'])
         self.assertIsNotNone(cd[0][0])
         self.assertIsNotNone(cd[0][1])
-        self.assertIsNotNone(cd[0][2])
         self.assertIsNotNone(cd[1][0])
         self.assertIsNotNone(cd[1][1])
-        self.assertIsNotNone(cd[1][2])

--- a/splash/tests/test_request_filters.py
+++ b/splash/tests/test_request_filters.py
@@ -196,9 +196,21 @@ class AllowedSchemesTest(BaseRenderTest):
     # pytest -s --verbosity=6 ./splash/tests/test_request_filters.py -k test_disable_browser_caches
     def test_disable_browser_caches(self):
         # entries if run with caches enabled
-        # in this case we should have  [[content,content,content],[content,no content,no content]]
+        # in this case we should have  [[content,content,content],[content,content,no content]]
         ce = self.run_with_extra_args([])
+        self.assertIsNotNone(ce[0][0])
+        self.assertIsNotNone(ce[0][1])
+        self.assertIsNotNone(ce[0][2])
+        self.assertIsNotNone(ce[1][0])
+        self.assertIsNotNone(ce[1][1])
+        self.assertIsNone(ce[1][2])
+
         # entries if run with caches disabled 
         # in this case we should have  [[content,content,content],[content,content,content]]
         cd = self.run_with_extra_args(['--disable-browser-caches'])
-        print(json.dumps(ce))
+        self.assertIsNotNone(cd[0][0])
+        self.assertIsNotNone(cd[0][1])
+        self.assertIsNotNone(cd[0][2])
+        self.assertIsNotNone(cd[1][0])
+        self.assertIsNotNone(cd[1][1])
+        self.assertIsNotNone(cd[1][2])

--- a/splash/tests/test_request_filters.py
+++ b/splash/tests/test_request_filters.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 import shutil
+import re
+import json
 
 import requests
 import pytest
@@ -140,6 +142,19 @@ class AllowedSchemesTest(BaseRenderTest):
     )
     FILE_URL = 'file://' + FILE_PATH
 
+    def findHAREntry(self, har, url_pattern):
+        """
+        Searches through the existing resources in the HAR contents for
+        the one that matches the request url agains the given url pattern.
+
+        Returns the first entry that matches the url pattern.
+        """
+        for e in har['log']['entries']:
+            if re.match(url_pattern,e['request']['url']):
+                return e
+        return None
+
+
     def test_file_scheme_disabled_by_default(self):
         assert os.path.isfile(self.FILE_PATH)
         r = self.request({'url': self.FILE_URL})
@@ -155,3 +170,35 @@ class AllowedSchemesTest(BaseRenderTest):
 
         self.assertStatusCode(r, 200)
         self.assertIn('script.js', r.text)
+
+    def run_with_extra_args(self, extra_args): 
+        with SplashServer(extra_args=extra_args) as splash:
+            test_url = self.mockurl('subresources-with-caching')
+            render_url = splash.url('render.har')
+
+            # 1st page fetch
+            r = requests.get(render_url, params={'url': test_url, 'response_body': 1})
+            self.assertStatusCode(r, 200)
+            entry11 = self.findHAREntry(r.json(),r"^.*subresources-with-caching$")
+            entry12 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/style.css$")
+            entry13 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/img.gif$")
+
+            # 2nd page fetch
+            r = requests.get(render_url, params={'url': test_url, 'response_body': 1})
+            self.assertStatusCode(r, 200)
+            entry21 = self.findHAREntry(r.json(),r"^.*subresources-with-caching$")
+            entry22 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/style.css$")
+            entry23 = self.findHAREntry(r.json(),r"^.*subresources-with-caching/img.gif$")
+
+            return [[entry11,entry12,entry13],[entry21,entry22,entry23]]
+
+    # run just this test using
+    # pytest -s --verbosity=6 ./splash/tests/test_request_filters.py -k test_disable_browser_caches
+    def test_disable_browser_caches(self):
+        # entries if run with caches enabled
+        # in this case we should have  [[content,content,content],[content,no content,no content]]
+        ce = self.run_with_extra_args([])
+        # entries if run with caches disabled 
+        # in this case we should have  [[content,content,content],[content,content,content]]
+        cd = self.run_with_extra_args(['--disable-browser-caches'])
+        print(json.dumps(ce))


### PR DESCRIPTION
Hi, I've been reading through the existing open issues.
This pull request is intended to address #203 , #519 , scrapy-plugins/scrapy-splash#168 , #817 , webrecorder/har2warc#1

Please review

Thanks,
Stefan

Note: To try this out, you can use this docker image:

    docker pull wsdookadr/splash:v1
    docker run -it -p 8050:8050  --name splash_v1 wsdookadr/splash:v1 --disable-browser-caches

And then load a web page and generate a .har file from it like so

    curl "http://localhost:8050/render.har?url=https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-debian-9&timeout=13&wait=4&response_body=1" > /tmp/q.har

If you run this multiple times, the amount of data fetched by curl should be about the same (4mb for that url). Before this pull-request, the first time, it would produce around 4mb, and the subsequent ones about ~200-300k (the .har files would be missing resources that are cached by webkit in its page cache, the first time the page was loaded). 

