### PR TITLE
upgrade Pillow to 5.4.1

### DIFF
--- a/dockerfiles/splash/provision.sh
+++ b/dockerfiles/splash/provision.sh
@@ -197,7 +197,7 @@ install_python_deps () {
         adblockparser==0.7 \
         xvfbwrapper==0.2.9 \
         funcparserlib==0.3.6 \
-        Pillow==3.4.2 \
+        Pillow==5.4.1 \
         lupa==1.3 && \
     ${_PYTHON} -m pip install https://github.com/sunu/pyre2/archive/c610be52c3b5379b257d56fc0669d022fd70082a.zip#egg=re2
 }

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup_args = {
         'adblockparser',
         'xvfbwrapper',
         'funcparserlib',
-        'Pillow > 2.0',
+        'Pillow >= 3.4.2',
     ],
     'classifiers': [
         'Programming Language :: Python',


### PR DESCRIPTION
* use RGB internally when working with jpeg images; this should save some RAM
* remove a workaround for transparent background (seems to be resolved by changes in qt / qtwebkit)