### PR TITLE
reduce default slots to 20

### DIFF
--- a/splash/defaults.py
+++ b/splash/defaults.py
@@ -66,7 +66,7 @@ SPLASH_PORT = 8050
 SPLASH_IP = '0.0.0.0'
 
 # pool options
-SLOTS = 50
+SLOTS = 20
 
 # argument cache option
 ARGUMENT_CACHE_MAX_ENTRIES = 500


### PR DESCRIPTION
50 is very high; I've actually never seen anything above 10 useful, besides basic benchmarks.