### PR TITLE
upgrade twisted to 18.9.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ Other improvements:
 * qt5reactor is upgraded to 0.5 - this should slightly reduce idle CPU usage;
 * Pillow is upgraded to 5.4.1 - as a side effect, taking large JPEG screenshots
   should use slightly less RAM;
-* Twisted is upgraded from 16.1.0 to 18.7.0;
+* Twisted is upgraded from 16.1.0 to 18.9.0;
 * a workaround for JPEG + transparency on a web page is removed, as it seems
   to do nothing;
 * Splash-Jupyter is updated to latest jupyter (ipykernel==5.1.0,

--- a/dockerfiles/splash/provision.sh
+++ b/dockerfiles/splash/provision.sh
@@ -193,7 +193,7 @@ install_python_deps () {
     ${_PYTHON} -m pip install \
         qt5reactor==0.5 \
         psutil==5.0.0 \
-        Twisted==18.7.0 \
+        Twisted==18.9.0 \
         adblockparser==0.7 \
         xvfbwrapper==0.2.9 \
         funcparserlib==0.3.6 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # install PyQt5 (Splash is tested on PyQT 5.9)
 # and the following packages:
-twisted == 18.7.0
+twisted == 18.9.0
 qt5reactor
 psutil
 adblockparser >= 0.5

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup_args = {
     ]},
     'zip_safe': False,
     'install_requires': [
-        'Twisted >= 18.7.0',
+        'Twisted >= 18.9.0',
         'qt5reactor',
         'psutil',
         'adblockparser',


### PR DESCRIPTION
It turns out 18.9.0 is the latest version, not 18.7.0,
even though the latest blog post and tweet are about 18.7.0