### PR TITLE
DOC cleanup FAQ entry about Splash crashes

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -260,9 +260,7 @@ https://github.com/nabilm/ansible-splash.
 Website is not rendered correctly
 ---------------------------------
 
-Sometimes websites are not rendered correctly by Splash.
-
-Common reasons:
+Sometimes websites are not rendered correctly by Splash. Common reasons:
 
 * not enough wait time; solution - wait more (see e.g. :ref:`splash-wait`);
 * non-working localStorage in Private Mode. This is a common issue e.g. for
@@ -292,49 +290,64 @@ Common reasons:
   A quick (though not precise) way to check it is to try opening a page
   in Safari.
 
+.. _IndexedDB: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Splash crashes
----------------
+--------------
 
 Common reasons:
 
-* Qt or WebKit bugs which cause Splash to hang or crash. Often the whole
-  website works, but some specific .js (or other) file causes problems.
-  In this case you can try these steps:
+* Qt or WebKit bugs which cause Splash to hang or crash. Unfortunately,
+  they can be hard to fix in Splash, as Splash is relying on these projects.
+  That said, often the whole website works, but some specific .js (or other)
+  file causes problems. In this case you can try these steps:
   
-  * Run Splash locally with v2 verbosity, e.g. ``docker run -it -p8050:8050 scrapinghub/splash -v2``
-  * Go to ``http://0.0.0.0:8050`` and paste your url (with default lua)
-  * Look at the log in terminal.
-  * If Splash instance failed and stopped - go to the next steps. For example the last request was to the url like ``https://.../static/tagtag.min.js`` with JS,  and we can suspect that probably it caused the issue.
-  * Try to filter out this script with using :ref:`splash-on-request` with this template (or use use :ref:`request filters` to filter it out) :
+  * Run Splash locally with v2 verbosity, e.g.
+    ``docker run -it -p8050:8050 scrapinghub/splash -v2``
+  * Go to ``http://0.0.0.0:8050`` and paste your url (with the default Lua
+    script), or try to reproduce the issue otherwise, using this Splash
+    instance.
+  * If Splash instance failed and stopped (you reproduced the issue),
+    check the log in terminal. Pay special attention to network activity.
+    For example, if the last response was for an url like
+    ``https://example.com/static/myscript123.min.js`` with JS, we may suspect
+    that this particular JavaScript file contains some code which makes
+    Splash crash.
+  * Filter out this .js file using :ref:`splash-on-request`:
   
     .. code-block:: lua
-    function main(splash, args)
-        splash:on_request(function(request)
-            if request.url:find('tagtag') ~= nil then
-                request:abort()
-            end
-        end)
-        assert(splash:go(args.url))
-        assert(splash:wait(0.5))
-        return {
-            html = splash:html(),
-            png = splash:png(),
-            har = splash:har(),
-        }
-    end
-  
+
+        function main(splash, args)
+            splash:on_request(function(request)
+                if request.url:find('myscript123') ~= nil then
+                    request:abort()
+                end
+            end)
+            assert(splash:go(args.url))
+            assert(splash:wait(0.5))
+            return {
+                html = splash:html(),
+                png = splash:png(),
+                har = splash:har(),
+            }
+        end
+
+    Alternatively, use :ref:`request filters` to filter it out.
+
 * Some of the crashes can be solved by disabling HTML 5 media
   (:ref:`splash-html5-media-enabled` property or
   :ref:`html5_media <arg-html5-media>` HTTP API argument) - note it is
   disabled by default.
 
+* Sometimes Splash may crash, and you get a Python traceback in the log.
+  In this case it is likely to be a Splash bug which can be fixed in Splash.
+  Please report it at https://github.com/scrapinghub/splash/issues, pasting
+  the whole traceback and parameters of the request you're making, if possible
+  (URL, endpoint or Lua script used).
 
 If you have troubles making Splash work, consider asking a question
 at https://stackoverflow.com. If you think it is a Splash bug,
 raise an issue at https://github.com/scrapinghub/splash/issues.
-
-.. _IndexedDB: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 .. _disable-private-mode:
 


### PR DESCRIPTION
* fix ReST syntax (code-block was raising a syntax error because of
  a wrong indentation);
* move IndexedDB link to a previous section, where it is used;
* wording;
* mention Splash crashes caused by Splash bugs.