### PR TITLE
fix a crash in splash:wait_for_resume

### DIFF
--- a/splash/exceptions.py
+++ b/splash/exceptions.py
@@ -47,11 +47,6 @@ class JsError(Exception):
     pass
 
 
-class OneShotCallbackError(Exception):
-    """ A one shot callback was called more than once. """
-    pass
-
-
 class DOMError(Exception):
     """ Error occurred during DOM operations"""
     NOT_IN_DOM_ERROR = 'NOT_IN_DOM_ERROR'


### PR DESCRIPTION
It looks like recent PyQT versions exit the process if a Python function called from JS raises an exception.