### PR TITLE
fix tests for webengine request and add a invalid engine name test

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -39,13 +39,13 @@ testing Docker container.
 
 3. Run tests inside this testing image::
 
-      docker run -it splash-tests
+      docker run --rm -it splash-tests
 
    You can also pass pytest command-line arguments in the command above.
    For example, you can select only a subset of tests to execute
    (SandboxTest test case in this example)::
 
-      docker run -it splash-tests -k SandboxTest
+      docker run --rm -it splash-tests -k SandboxTest
 
 If you've changed Splash source code and want to re-run tests, repeat steps
 (2) and (3). Step (2) should take much less time now.

--- a/splash/qtrender_image.py
+++ b/splash/qtrender_image.py
@@ -301,7 +301,7 @@ class QtImageRenderer(object):
                         QPoint(ceil((left + tile_qimage.width()) / ratio),
                                ceil((top + tile_qimage.height()) / ratio)))
                     self.web_page.mainFrame().render(painter, QRegion(clip_rect))
-                    tile_image = self.qimage_to_pil_image(tile_qimage)
+                    tile_image = self._qimage_to_pil_image(tile_qimage)
 
                     # If this is the bottommost tile, its bottom may have stuff
                     # left over from rendering the previous tile.  Make sure

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -1105,12 +1105,12 @@ class RenderJpegTest(Base.RenderTest):
             self.assertStatusCode(r, 400)
 
 
-class InvalidEngineRequestHandler(DirectRequestHandler):
+class InvalidEngineNameRequestHandler(DirectRequestHandler):
     engine = 'invalid'
 
 
 class InvalidEngineNameTest(BaseRenderTest):
-    request_handler = InvalidEngineRequestHandler
+    request_handler = InvalidEngineNameRequestHandler
 
     def test_invalid_engine(self):
         url = self.mockurl('getrequest') + '?code=200'

--- a/splash/tests/test_render.py
+++ b/splash/tests/test_render.py
@@ -1103,3 +1103,17 @@ class RenderJpegTest(Base.RenderTest):
             r = self.request({'url': self.mockurl("jsrender"),
                               'scale_method': method})
             self.assertStatusCode(r, 400)
+
+
+class InvalidEngineRequestHandler(DirectRequestHandler):
+    engine = 'invalid'
+
+
+class InvalidEngineNameTest(BaseRenderTest):
+    request_handler = InvalidEngineRequestHandler
+
+    def test_invalid_engine(self):
+        url = self.mockurl('getrequest') + '?code=200'
+        r = self.request({'url': url})
+        self.assertStatusCode(r, 400)
+        self.assertIn("Unsupported render engine", r.text)


### PR DESCRIPTION
The travis tests for #867  are failed with
```
E   AssertionError: 400 != 200 : (400, 
'{"info": {"message": "Lua error: AttributeError(\\"\'QtImageRenderer\' object has no attribute 
\'qimage_to_pil_image\'\\",)", "type": "LUA_ERROR"}, "description": "Error happened while executing Lua script", 
"error": 400, "type": "ScriptError"}',
 'http://localhost:44451/execute?url=http%3A%2F%2Flocalhost%3A49991%2Fvery-long-green-page&viewport=50x1024&render_all=1&engine=webkit&lua_source=main+%3D+require%28%22emulation%22%29.render_png&wait=0.01')
```

https://travis-ci.org/scrapinghub/splash/builds/496767326

I also add a test for invalid engine name.