### PR TITLE
upgrade qtwebkit to QtWebkit-5.212.3-alpha3

### DIFF
--- a/dockerfiles/splash/build-qtwebkit.sh
+++ b/dockerfiles/splash/build-qtwebkit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+mkdir -p /tmp/builds/qtwebkit && \
+cd /tmp/builds && \
+tar xvfJ "$1" --keep-newer-files --strip-components 1 && \
+mkdir build && \
+cd build && \
+cmake -G Ninja -DPORT=Qt -DCMAKE_BUILD_TYPE=Release .. && \
+ninja && \
+ninja install

--- a/dockerfiles/splash/download-qtwebkit-source.sh
+++ b/dockerfiles/splash/download-qtwebkit-source.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+URL="https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-5.212.0-alpha3/qtwebkit-5.212.0-alpha3.tar.xz"
+curl -L -o "$1" ${URL}

--- a/dockerfiles/splash/install-qtwebkit-build-deps.sh
+++ b/dockerfiles/splash/install-qtwebkit-build-deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+apt-get install -y --no-install-recommends \
+    cmake \
+    ninja-build \
+    bison \
+    gperf \
+    ruby \
+    python

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -1013,6 +1013,22 @@ class InvalidStatusMessageResource(Resource):
         return b'ok'
 
 
+class RedirectAndHashtagsResource(Resource):
+    attempts = 0
+
+    def render_GET(self, request):
+        # redirect to same url on every other request
+        if self.attempts % 2 == 0:
+            request.setResponseCode(302)
+            request.setHeader(b"Location", request.uri)
+            self.attempts += 1
+            return b""
+        else:
+            request.setResponseCode(200)
+            return b"""
+            <html><head></head><body>Hello world</body></html>
+            """
+
 class Index(Resource):
     isLeaf = True
 
@@ -1119,6 +1135,7 @@ class Root(Resource):
         self.putChild(b"meta-redirect1", MetaRedirect1())
         self.putChild(b"meta-redirect-target", MetaRedirectTarget())
         self.putChild(b"http-redirect", HttpRedirectResource())
+        self.putChild(b"redirect-hash", RedirectAndHashtagsResource())
 
         self.putChild(b"do-post", XHRPostPage())
 

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -1857,6 +1857,24 @@ class GoTest(BaseLuaRenderTest):
         self.assertStatusCode(resp, 400)
         self.assertIn("request body must be a string", resp.text)
 
+    def test_go_redirect_hashurl_status_200(self):
+        resp = self.request_lua("""
+        function main(splash)
+            assert(splash:go(splash.args.url))
+            return splash:url()
+        end""", {"url": self.mockurl("jsrender#keep-this-part")})
+        self.assertStatusCode(resp, 200)
+        self.assertIn("jsrender#keep-this-part", resp.text)
+
+    def test_go_redirect_hashurl_status_302(self):
+        resp = self.request_lua("""
+        function main(splash)
+            assert(splash:go(splash.args.url))
+            return splash:url()
+        end""", {"url": self.mockurl("redirect-hash#keep-this-part")})
+        self.assertStatusCode(resp, 200)
+        self.assertIn("redirect-hash#keep-this-part", resp.text)
+
 
 class ResourceTimeoutTest(BaseLuaRenderTest):
     if not has_min_qt_version('5.5.1'):


### PR DESCRIPTION
Currently this builds qtwebkit as a part of Docker build. It may be too heavy for CI, let's see.

Fixes #470.