### PR TITLE
Use a more recent qtwebkit snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY dockerfiles/splash/run-qt-installer.sh /tmp/run-qt-installer.sh
 RUN /tmp/run-qt-installer.sh /tmp/qt-installer.run /tmp/script.qs
 
 # XXX: this needs to be updated if Qt is updated
-ENV PATH="/opt/qt-5.13/5.13.0/gcc_64/bin:${PATH}"
+ENV PATH="/opt/qt-5.13/5.13.1/gcc_64/bin:${PATH}"
 
 # install qtwebkit
 COPY --from=qtwebkit-downloader /tmp/qtwebkit.7z /tmp/
@@ -81,10 +81,10 @@ COPY dockerfiles/splash/install-system-splash-deps.sh /tmp/install-system-splash
 RUN /tmp/install-system-splash-deps.sh
 
 # XXX: this needs to be updated if Qt is updated
-COPY --from=qtbuilder /opt/qt-5.13/5.13.0/gcc_64 /opt/qt-5.13/5.13.0/gcc_64
+COPY --from=qtbuilder /opt/qt-5.13/5.13.1/gcc_64 /opt/qt-5.13/5.13.1/gcc_64
 #RUN ls -l /opt/qt-5.13/5.13.0/gcc_64/lib
-ENV PATH="/opt/qt-5.13/5.13.0/gcc_64/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/qt-5.13/5.13.0/gcc_64/lib:$LD_LIBRARY_PATH"
+ENV PATH="/opt/qt-5.13/5.13.1/gcc_64/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/qt-5.13/5.13.1/gcc_64/lib:$LD_LIBRARY_PATH"
 
 # =====================
 

--- a/dockerfiles/splash/download-pyqt5.sh
+++ b/dockerfiles/splash/download-pyqt5.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 # XXX: these URLs needs to be replaced with sourceforge in future,
 # because riverbank tend to remove old releases.
-SIP="https://www.riverbankcomputing.com/static/Downloads/sip/4.19.18/sip-4.19.18.tar.gz"
-PYQT5="https://www.riverbankcomputing.com/static/Downloads/PyQt5/5.13.0/PyQt5_gpl-5.13.0.tar.gz"
-WEBENGINE="https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/5.13.0/PyQtWebEngine_gpl-5.13.0.tar.gz"
+SIP="https://www.riverbankcomputing.com/static/Downloads/sip/4.19.19/sip-4.19.19.tar.gz"
+PYQT5="https://www.riverbankcomputing.com/static/Downloads/PyQt5/5.13.1/PyQt5_gpl-5.13.1.tar.gz"
+WEBENGINE="https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/5.13.1/PyQtWebEngine_gpl-5.13.1.tar.gz"
 
 curl -L -o "$1" ${SIP} && \
 curl -L -o "$2" ${PYQT5} && \

--- a/dockerfiles/splash/download-qt-installer.sh
+++ b/dockerfiles/splash/download-qt-installer.sh
@@ -2,6 +2,6 @@
 
 # XXX: if qt version is changed, Dockerfile should be updated,
 # as well as qt-installer-noninteractive.qs script.
-URL="http://download.qt.io/official_releases/qt/5.13/5.13.0/qt-opensource-linux-x64-5.13.0.run"
+URL="http://download.qt.io/official_releases/qt/5.13/5.13.1/qt-opensource-linux-x64-5.13.1.run"
 
 curl -L -o "$1" ${URL}

--- a/dockerfiles/splash/download-qtwebkit.sh
+++ b/dockerfiles/splash/download-qtwebkit.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-URL="https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-5.212.0-alpha3/qtwebkit-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z"
+URL="http://download.qt.io/snapshots/ci/qtwebkit/5.212/1570542016/qtwebkit/qtwebkit-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z"
 curl -L -o "$1" ${URL}

--- a/dockerfiles/splash/download-qtwebkit.sh
+++ b/dockerfiles/splash/download-qtwebkit.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-URL="http://download.qt.io/snapshots/ci/qtwebkit/5.212/1570542016/qtwebkit/qtwebkit-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z"
+URL="https://download.qt.io/snapshots/ci/qtwebkit/5.212/1570542016/qtwebkit/qtwebkit-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z"
 curl -L -o "$1" ${URL}

--- a/dockerfiles/splash/install-qtwebkit.sh
+++ b/dockerfiles/splash/install-qtwebkit.sh
@@ -4,6 +4,8 @@ apt-get install -y p7zip-full && \
 mkdir -p /tmp/builds/qtwebkit && \
 cd /tmp/builds/qtwebkit && \
 cp "$1" ./webkit.7z && \
-7z x ./webkit.7z && \
+7z x ./webkit.7z -xr!*.debug && \
 rm webkit.7z && \
-rsync -aP /tmp/builds/qtwebkit/* `qmake -query QT_INSTALL_PREFIX`
+rsync \
+  -aP /tmp/builds/qtwebkit/* \
+  $(qmake -query QT_INSTALL_PREFIX)

--- a/dockerfiles/splash/qt-installer-noninteractive.qs
+++ b/dockerfiles/splash/qt-installer-noninteractive.qs
@@ -30,9 +30,9 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var components = [
-      "qt.qt5.5130.gcc_64",
-      "qt.qt5.5130.qtwebengine",
-      "qt.qt5.5130.qtnetworkauth",
+      "qt.qt5.5131.gcc_64",
+      "qt.qt5.5131.qtwebengine",
+      "qt.qt5.5131.qtnetworkauth",
     ]
     console.log("Select components");
     var widget = gui.currentPageWidget();

--- a/splash/tests/mockserver.py
+++ b/splash/tests/mockserver.py
@@ -774,7 +774,7 @@ VariousElementsPage = _html_resource("""
 <html>
 <head>
 <style>
-  html, body { margin: 0; padding: 0; }
+  html, body { margin: 0; padding: 0; height: 100%% }
 </style>
 </head>
 <body>


### PR DESCRIPTION
* qt is upgraded to 5.13.1
* PyTQ and related packages are also upgraded
* qtwebkit is installed from a recent snapshot
  (http://download.qt.io/snapshots/ci/qtwebkit/5.212/1570542016/);
  debug files are removed to reduce docker image size
* there is a rendering change (body height is different); tests
  are adapted for this

This should allow to enable http2 by defualt, as an issue is fixed.

See also: https://github.com/scrapinghub/splash/pull/944