### PR TITLE
Configure bumpversion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,18 @@
+[bumpversion]
+current_version = 3.4.0
+commit = True
+tag = True
+tag_name = "{new_version}"
+
+[bumpversion:file:splash/__init__.py]
+serialize =
+  {major}.{minor}.{patch}
+  {major}.{minor}
+
+[bumpversion:file:docs/conf.py]
+serialize =
+  {major}.{minor}
+
 [tool:pytest]
 norecursedirs = bin debian dist docs examples notebooks splash/kernel
 doctest_optionflags = ALLOW_UNICODE


### PR DESCRIPTION
Running `bumpversion --dry-run --verbose patch` with `bumpversion` installed after these changes seems to describe the right list of changes to apply.