### PR TITLE
[docs] Update method syntax (`.` syntax provide errors).

### DIFF
--- a/docs/scripting-tutorial.rst
+++ b/docs/scripting-tutorial.rst
@@ -116,7 +116,7 @@ Here is a snippet from our first example:
 
 The code looks like standard procedural code; there are no callbacks or fancy
 control-flow structures. It doesn't mean Splash works in a synchronous
-way; under the hood it is still async. When you call ``splash.wait(0.5)``,
+way; under the hood it is still async. When you call ``splash:wait(0.5)``,
 Splash switches from the script to other tasks, and comes back after 0.5s.
 
 It is possible to use loops, conditional statements, functions as usual

--- a/splash/examples/render-multiple.lua
+++ b/splash/examples/render-multiple.lua
@@ -1,6 +1,6 @@
 function main(splash, args)
-  splash.set_viewport_size(800, 600)
-  splash.set_user_agent('Splash bot')
+  splash:set_viewport_size(800, 600)
+  splash:set_user_agent('Splash bot')
   local example_urls = {"www.google.com", "www.bbc.co.uk", "scrapinghub.com"}
   local urls = args.urls or example_urls
   local results = {}

--- a/splash/tests/test_execute.py
+++ b/splash/tests/test_execute.py
@@ -361,7 +361,7 @@ class ErrorsTest(BaseLuaRenderTest):
         resp = self.request_lua("""                -- 1
         function main(splash)                      -- 2
            local x = 5                             -- 3
-           splash.set_result_content_type("hello") -- 4
+           splash:set_result_content_type("hello") -- 4
         end                                        -- 5
         """)
         self.assertScriptError(resp, ScriptError.SPLASH_LUA_ERROR)


### PR DESCRIPTION
Some methods from docs and examples use the wrong syntax (`.` instead of `:`). It causes straight errors for newcomers.

Also, the method `splash:html()` still works as `splash.html()`, and the method `splash:url()` still works as `splash.url()`, but maybe it's better to change all usages to `:`, as documentation says?