### PR TITLE
[tests] Update `:html` method usage.

### DIFF
--- a/splash/tests/test_execute_callbacks.py
+++ b/splash/tests/test_execute_callbacks.py
@@ -114,7 +114,7 @@ class OnRequestTest(BaseLuaRenderTest, BaseHtmlProxyTest):
                 }
             end)
             assert(splash:go(args.url))
-            return splash.html()
+            return splash:html()
         end
         """ % self.ts.mock_auth_proxy_user, {
             'url': self.mockurl("jsrender"), 'proxy_port': proxy_port
@@ -135,7 +135,7 @@ class OnRequestTest(BaseLuaRenderTest, BaseHtmlProxyTest):
                 }
             end)
             assert(splash:go(args.url))
-            return splash.html()
+            return splash:html()
         end
         """, {'url': self.mockurl("jsrender"), 'proxy_port': proxy_port})
         self.assertStatusCode(resp, 400)


### PR DESCRIPTION
Updating `.html()` to `:html()` as documentation says.