### PR TITLE
Changed the lupa imports un jupyter kernel

### DIFF
--- a/splash/kernel/errors.py
+++ b/splash/kernel/errors.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+import sys
+orig_dlflags = sys.getdlopenflags()
+sys.setdlopenflags(258)
 import lupa
+sys.setdlopenflags(orig_dlflags)
 
 from splash.errors import ScriptError
 from splash.lua import parse_error_message

--- a/splash/kernel/kernel.py
+++ b/splash/kernel/kernel.py
@@ -2,7 +2,12 @@
 import os
 import sys
 
+import sys
+orig_dlflags = sys.getdlopenflags()
+sys.setdlopenflags(258)
 import lupa
+sys.setdlopenflags(orig_dlflags)
+
 from ipykernel.kernelapp import IPKernelApp
 from ipykernel.eventloops import loop_qt5
 from jupyter_client.kernelspec import install_kernel_spec


### PR DESCRIPTION
Hello,

First thank you very much for providing such a great tool, it is awesome and I have used it in the past and come back to using it.

I propose that tiny change if you find it useful. With it, it becomes possible to require lua libraries using binary (*.so) files. The issue is that "CPython needs to enable global symbol visibility for shared libraries before loading the Lupa module" to quote directly the [lupa PyPI page](https://pypi.org/project/lupa/). So I just changed the visibility before loading lupa and changed it back afterwards for the jupyter notebook kernel. Without the change, while trying to require socket, python would not use the lua binaries and so it would ask for unknown functions such as lua_gettop.

My use of that change is that I want to automate things while using a Tor container, so I need to be able to create sockets which will tell Tor to create a new identity when the identity i have is not correct.

I asked for master because I didn't find any dev branch

I tried to run a splash notebook with my version of the code and I can now require socket and this simple code ran perfectly fine

```

splash:go("https://www.duckduckgo.com")
splash:wait(2)
splash:jpeg()

```

I ran the tests and got that, and as I don't know your project well enough to know if my change is the cause of those regressions, It would be great if you could give me some directions on that.

```

============================= test session starts ==============================
platform linux -- Python 3.6.9, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /app, inifile: setup.cfg
plugins: forked-1.1.3, xdist-1.31.0, cov-2.8.1
collected 1452 items

splash/argument_cache.py .                                               [  0%]
splash/html_element.py .                                                 [  0%]
splash/lua.py ..                                                         [  0%]
splash/response_middleware.py ..                                         [  0%]
splash/utils.py ..                                                       [  0%]
splash/tests/test_argument_caching.py ....                               [  0%]
splash/tests/test_callback_proxy.py .......                              [  1%]
splash/tests/test_client_disconnects.py ....                             [  1%]
splash/tests/test_completer.py ................x..........x....          [  3%]
splash/tests/test_execute.py ..................................x........ [  6%]
........................................................................ [ 11%]
........................................................................ [ 16%]
........................................................................ [ 21%]
....................x..........x...x.x.................................. [ 26%]
..............                                                           [ 27%]
splash/tests/test_execute_callbacks.py .......x...............x......... [ 29%]
........................                                                 [ 31%]
splash/tests/test_execute_element.py ................................... [ 33%]
.......................................                                  [ 36%]
splash/tests/test_execute_emulation.py .............x................... [ 38%]
.........x..x................x...................x......x............... [ 43%]
..........x......x.......................x..............XX.........      [ 48%]
splash/tests/test_execute_libraries.py ............................      [ 50%]
splash/tests/test_execute_request_filters.py ..                          [ 50%]
splash/tests/test_har.py ...................XX.......................... [ 53%]
........XX.......                                                        [ 54%]
splash/tests/test_har_utils.py ........                                  [ 55%]
splash/tests/test_jsonpost.py .......................................... [ 58%]
...............................................XX........x.............. [ 63%]
...........                                                              [ 64%]
splash/tests/test_jupyter.py s.ssssssss.s                                [ 64%]
splash/tests/test_lua_parser.py .......................xxx.............. [ 67%]
...........................                                              [ 69%]
splash/tests/test_lua_utils.py .........x........x.....                  [ 71%]
splash/tests/test_proxy.py ................s.s..                         [ 72%]
splash/tests/test_qtutils.py .                                           [ 72%]
splash/tests/test_redirects.py ................................          [ 74%]
splash/tests/test_render.py ............................................ [ 77%]
........................X............................................... [ 82%]
........................................................................ [ 87%]
.F..                                                                     [ 88%]
splash/tests/test_render_chromium.py ....xx..sss.........s.....xx....... [ 90%]
Xx........s.xx.xxxx..xxx.......Xx........s.xx.xx..xxx........x.x.x.x.... [ 95%]
........s..xxxx...x.                                                     [ 96%]
splash/tests/test_request_body_lua.py ...                                [ 97%]
splash/tests/test_request_filters.py .x........                          [ 97%]
splash/tests/test_response_middleware.py .....x                          [ 98%]
splash/tests/test_response_tracking.py ..                                [ 98%]
splash/tests/test_run.py .                                               [ 98%]
splash/tests/test_runjs.py ............                                  [ 99%]
splash/tests/test_ui.py .                                                [ 99%]
splash/tests/test_utils.py ...........                                   [100%]

=================================== FAILURES ===================================
_____________ DisabledEnginesTest.test_browser_engines_all_enabled _____________
/usr/local/lib/python3.6/dist-packages/urllib3/connectionpool.py:421: in _make_request
    six.raise_from(e, None)
<string>:3: in raise_from
    ???
/usr/local/lib/python3.6/dist-packages/urllib3/connectionpool.py:416: in _make_request
    httplib_response = conn.getresponse()
/usr/lib/python3.6/http/client.py:1346: in getresponse
    response.begin()
/usr/lib/python3.6/http/client.py:307: in begin
    version, status, reason = self._read_status()
/usr/lib/python3.6/http/client.py:268: in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
/usr/lib/python3.6/socket.py:586: in readinto
    return self._sock.recv_into(b)
E   socket.timeout: timed out

During handling of the above exception, another exception occurred:
/usr/local/lib/python3.6/dist-packages/requests/adapters.py:449: in send
    timeout=timeout
/usr/local/lib/python3.6/dist-packages/urllib3/connectionpool.py:720: in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
/usr/local/lib/python3.6/dist-packages/urllib3/util/retry.py:400: in increment
    raise six.reraise(type(error), error, _stacktrace)
/usr/local/lib/python3.6/dist-packages/urllib3/packages/six.py:735: in reraise
    raise value
/usr/local/lib/python3.6/dist-packages/urllib3/connectionpool.py:672: in urlopen
    chunked=chunked,
/usr/local/lib/python3.6/dist-packages/urllib3/connectionpool.py:423: in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
/usr/local/lib/python3.6/dist-packages/urllib3/connectionpool.py:331: in _raise_timeout
    self, url, "Read timed out. (read timeout=%s)" % timeout_value
E   urllib3.exceptions.ReadTimeoutError: HTTPConnectionPool(host='localhost', port=49363): Read timed out. (read timeout=3.0)

During handling of the above exception, another exception occurred:
splash/tests/test_render.py:1185: in test_browser_engines_all_enabled
    resp = self._request_html(splash, {'url': url, 'engine': 'chromium'})
splash/tests/test_render.py:1159: in _request_html
    return requests.get(splash.url('render.html'), params=params, timeout=3.0)
/usr/local/lib/python3.6/dist-packages/requests/api.py:75: in get
    return request('get', url, params=params, **kwargs)
/usr/local/lib/python3.6/dist-packages/requests/api.py:60: in request
    return session.request(method=method, url=url, **kwargs)
/usr/local/lib/python3.6/dist-packages/requests/sessions.py:533: in request
    resp = self.send(prep, **send_kwargs)
/usr/local/lib/python3.6/dist-packages/requests/sessions.py:646: in send
    r = adapter.send(request, **kwargs)
/usr/local/lib/python3.6/dist-packages/requests/adapters.py:529: in send
    raise ReadTimeout(e, request=request)
E   requests.exceptions.ReadTimeout: HTTPConnectionPool(host='localhost', port=49363): Read timed out. (read timeout=3.0)
----------------------------- Captured stdout call -----------------------------
2020-02-06 17:43:42+0000 [-] "127.0.0.1" - - [06/Feb/2020:17:43:41 +0000] "GET /getrequest?code=200 HTTP/1.1" 200 455 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/602.1 (KHTML, like Gecko) server.py Version/10.0 Safari/602.1"
2020-02-06 17:43:44+0000 [-] "127.0.0.1" - - [06/Feb/2020:17:43:44 +0000] "GET /getrequest?code=200 HTTP/1.1" 200 507 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.13.1 Chrome/73.0.3683.105 Safari/537.36"
----------------------------- Captured stderr call -----------------------------
Coverage.py warning: --include is ignored because --source is set (include-ignored)
2020-02-06 17:43:41+0000 [-] Log opened.
2020-02-06 17:43:41.757148 [-] Xvfb is started: ['Xvfb', ':1560989588', '-screen', '0', '1024x768x24', '-nolisten', 'tcp']
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-splash'
2020-02-06 17:43:41.971771 [-] Splash version: 3.4.1
2020-02-06 17:43:41.999291 [-] Qt 5.13.1, PyQt 5.13.1, WebKit 602.1, Chromium 73.0.3683.105, sip 4.19.19, Twisted 19.7.0, Lua 5.2
2020-02-06 17:43:41.999464 [-] Python 3.6.9 (default, Nov  7 2019, 10:44:02) [GCC 8.3.0]
2020-02-06 17:43:41.999567 [-] Open files limit: 1048576
2020-02-06 17:43:41.999631 [-] Can't bump open files limit
2020-02-06 17:43:42.002539 [-] memory cache: enabled, private mode: enabled, js cross-domain access: disabled
2020-02-06 17:43:42.100840 [-] verbosity=3, slots=5, argument_cache_max_entries=500, max-timeout=90.0
2020-02-06 17:43:42.100995 [-] Web UI: enabled, Lua: enabled (sandbox: enabled), Webkit: enabled, Chromium: enabled
2020-02-06 17:43:42.101500 [-] Site starting on 49363
2020-02-06 17:43:42.101578 [-] Starting factory <twisted.web.server.Site object at 0x7f1f2224c2e8>
2020-02-06 17:43:42.101768 [-] Server listening on http://0.0.0.0:49363
2020-02-06 17:43:42.145340 [pool] initializing SLOT 0
2020-02-06 17:43:42.177730 [render] [139771693549328] viewport size is set to 1024x768
2020-02-06 17:43:42.177915 [pool] [139771693549328] SLOT 0 is starting
2020-02-06 17:43:42.178082 [render] [139771693549328] viewport size is set to 1024x768
2020-02-06 17:43:42.178206 [render] [139771693549328] HAR event: _onStarted
2020-02-06 17:43:42.178349 [render] [139771693549328] callback 0 is connected to loadFinished
2020-02-06 17:43:42.179421 [network] [139771693549328] GET http://localhost:39135/getrequest?code=200
2020-02-06 17:43:42.180270 [pool] [139771693549328] SLOT 0 is working
2020-02-06 17:43:42.180382 [pool] [139771693549328] queued
2020-02-06 17:43:42.182004 [network-manager] Headers received for http://localhost:39135/getrequest?code=200
2020-02-06 17:43:42.183059 [network-manager] Finished downloading http://localhost:39135/getrequest?code=200
2020-02-06 17:43:42.187301 [render] [139771693549328] loadFinished: ok
2020-02-06 17:43:42.187403 [render] [139771693549328] loadFinished: disconnecting callback 0
2020-02-06 17:43:42.187492 [render] [139771693549328] loadFinished; not waiting
2020-02-06 17:43:42.187566 [render] [139771693549328] _loadFinishedOK
2020-02-06 17:43:42.187631 [render] [139771693549328] stop_loading
2020-02-06 17:43:42.187709 [render] [139771693549328] HAR event: _onPrepareStart
2020-02-06 17:43:42.187787 [render] [139771693549328] getting HTML
2020-02-06 17:43:42.187888 [render] [139771693549328] HAR event: _onHtmlRendered
2020-02-06 17:43:42.187996 [pool] [139771693549328] SLOT 0 is closing <splash.engines.webkit.render_scripts.HtmlRender object at 0x7f1f2226a898>
2020-02-06 17:43:42.188073 [render] [139771693549328] close is requested by a script
2020-02-06 17:43:42.188355 [render] [139771693549328] cancelling 0 remaining timers
2020-02-06 17:43:42.188437 [pool] [139771693549328] SLOT 0 done with <splash.engines.webkit.render_scripts.HtmlRender object at 0x7f1f2226a898>
2020-02-06 17:43:42.189144 [events] {"path": "/render.html", "rendertime": 0.04395556449890137, "maxrss": 182852, "load": [0.77, 1.26, 1.54], "fds": 61, "active": 0, "qsize": 0, "_id": 139771693549328, "method": "GET", "timestamp": 1581011022, "user-agent": "python-requests/2.22.0", "args": {"url": "http://localhost:39135/getrequest?code=200", "engine": "webkit", "uid": 139771693549328}, "status_code": 200, "client_ip": "127.0.0.1"}
2020-02-06 17:43:42.189279 [-] "127.0.0.1" - - [06/Feb/2020:17:43:42 +0000] "GET /render.html?url=http%3A%2F%2Flocalhost%3A39135%2Fgetrequest%3Fcode%3D200&engine=webkit HTTP/1.1" 200 466 "-" "python-requests/2.22.0"
2020-02-06 17:43:42.189427 [pool] SLOT 0 is available
2020-02-06 17:43:42.193512 [pool] initializing SLOT 1
2020-02-06 17:43:42.250964 [render] [139771693672656] viewport size is set to 1024x768
2020-02-06 17:43:42.264410 [render] [139771693672656] real viewport size: PyQt5.QtCore.QSize(1024, 768)
2020-02-06 17:43:42.264962 [pool] [139771693672656] SLOT 1 is starting
2020-02-06 17:43:42.265420 [render] [139771693672656] viewport size is set to 1024x768
2020-02-06 17:43:42.265707 [render] [139771693672656] real viewport size: PyQt5.QtCore.QSize(1024, 768)
2020-02-06 17:43:42.266107 [render] [139771693672656] callback 0 is connected to loadFinished
2020-02-06 17:43:42.935097 [pool] [139771693672656] SLOT 1 is working
2020-02-06 17:43:42.935596 [pool] [139771693672656] queued
2020-02-06 17:43:45.195519 [_GenericHTTPChannelProtocol,2,127.0.0.1] Received SIGINT, shutting down.
2020-02-06 17:43:45.196117 [_GenericHTTPChannelProtocol,2,127.0.0.1] Client disconnected: Connection was closed cleanly.
2020-02-06 17:43:45.196754 [pool] [139771693672656] SLOT 1 finished with an error <splash.engines.chromium.render_scripts.ChromiumRenderHtmlScript object at 0x7f1f2221e4a8>: [Failure instance: Traceback (failure with no frames): <class 'twisted.internet.defer.CancelledError'>: 
	]
2020-02-06 17:43:45.197113 [pool] [139771693672656] SLOT 1 is closing <splash.engines.chromium.render_scripts.ChromiumRenderHtmlScript object at 0x7f1f2221e4a8>
2020-02-06 17:43:45.197543 [pool] SLOT 1 is available
2020-02-06 17:43:45.197978 [render] [139771693672656] close is requested by a script
2020-02-06 17:43:45.198682 [pool] [139771693672656] SLOT 1 done with <splash.engines.chromium.render_scripts.ChromiumRenderHtmlScript object at 0x7f1f2221e4a8>
2020-02-06 17:43:45.199951 [events] {"path": "/render.html", "rendertime": 3.0060744285583496, "maxrss": 236860, "load": [0.77, 1.26, 1.54], "fds": 63, "active": 0, "qsize": 0, "_id": 139771693672656, "method": "GET", "timestamp": 1581011025, "user-agent": "python-requests/2.22.0", "args": {"url": "http://localhost:39135/getrequest?code=200", "engine": "chromium", "uid": 139771693672656}, "status_code": 520, "client_ip": "127.0.0.1", "error": {"error": 520, "type": "CancelledError", "description": "Render is cancelled", "info": {"remaining": 27.736860036849976}}}
2020-02-06 17:43:45.200130 [twisted.web.server.Site] (TCP Port 49363 Closed)
2020-02-06 17:43:45.200221 [-] Stopping factory <twisted.web.server.Site object at 0x7f1f2224c2e8>
=============================== warnings summary ===============================
splash/tests/test_jupyter.py::SplashKernelTest::test_clear_output
  /usr/local/lib/python3.6/dist-packages/jupyter_client/kernelspec.py:372: DeprecationWarning: replace is ignored. Installing a kernelspec always replaces an existing installation
    user, replace, prefix)

splash/tests/test_jupyter.py::SplashKernelTest::test_clear_output
  /usr/local/lib/python3.6/dist-packages/jupyter_client/manager.py:72: DeprecationWarning: KernelManager._kernel_name_changed is deprecated in traitlets 4.1: use @observe and @unobserve instead.
    def _kernel_name_changed(self, name, old, new):

splash/tests/test_render.py::TestTestSetup::test_mockserver_https_works
  /usr/local/lib/python3.6/dist-packages/urllib3/connectionpool.py:1004: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform linux, python 3.6.9-final-0 -----------
Name                                        Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------------------------
splash/__init__.py                              4      0      0      0   100%
splash/_cmdline_utils.py                       11      0      6      1    94%
splash/argument_cache.py                       35      1     12      1    96%
splash/browser_tab.py                         211      3     36      5    97%
splash/casperjs_utils.py                        5      0      0      0   100%
splash/cookies.py                              67      3     34      3    92%
splash/defaults.py                             41      0      0      0   100%
splash/engines/__init__.py                      0      0      0      0   100%
splash/engines/chromium/__init__.py             1      0      0      0   100%
splash/engines/chromium/browser_tab.py        111     10     20      4    88%
splash/engines/chromium/constants.py            2      0      0      0   100%
splash/engines/chromium/render_scripts.py      77     13     32     12    77%
splash/engines/chromium/screenshot.py          27      3      4      2    84%
splash/engines/chromium/webpage.py             19      3      6      3    76%
splash/engines/webkit/__init__.py               1      0      0      0   100%
splash/engines/webkit/browser_tab.py          454     17    106     12    94%
splash/engines/webkit/http_client.py           91      3     30      2    96%
splash/engines/webkit/render_scripts.py        99      2     34      3    96%
splash/engines/webkit/screenshot.py            68      1     10      1    97%
splash/engines/webkit/webpage.py              129     25     32      5    75%
splash/engines/webkit/webview.py               10      1      4      2    79%
splash/errors.py                               34      0      2      0   100%
splash/har/__init__.py                          1      0      0      0   100%
splash/har/log.py                              76      1     28      3    96%
splash/har/qt.py                               77      2     34      2    96%
splash/har/schema.py                           10      0      0      0   100%
splash/har/utils.py                            31      1     14      1    96%
splash/har_builder.py                         102     18     28      4    78%
splash/html_element.py                        148      1     26      1    99%
splash/jsutils.py                              11      0      0      0   100%
splash/kernel/__init__.py                       0      0      0      0   100%
splash/kernel/__main__.py                       6      1      2      1    75%
splash/kernel/completer.py                     77      2     38      1    97%
splash/kernel/errors.py                        20     12      6      0    31%
splash/kernel/inspections.py                   57     30     26      1    36%
splash/kernel/kernel.py                       151     67     12      1    52%
splash/kernel/kernelbase.py                    68     34     20      1    51%
splash/kernel/lua_parser.py                   151      5     30      2    96%
splash/log.py                                  15      1      4      1    89%
splash/lua.py                                 151     14     76      4    91%
splash/lua_runner.py                          116     10     22      3    91%
splash/lua_runtime.py                          83      6     16      3    91%
splash/network_manager.py                     307     28    102     19    88%
splash/pool.py                                 65      0     10      2    97%
splash/proxy.py                               106     13     34      2    88%
splash/qtrender_image.py                      204     16     48      7    91%
splash/qtrender_lua.py                       1321     32    329     24    97%
splash/qtutils.py                             166     19     58     11    85%
splash/render_options.py                      247      4    101      6    97%
splash/render_scripts.py                       56      5     10      3    88%
splash/request_middleware.py                  131     13     58     14    85%
splash/resources.py                           348     36     73     11    86%
splash/response_middleware.py                  33      0     12      1    98%
splash/sentry.py                               16      7      4      0    45%
splash/server.py                              194     28     54     13    83%
splash/utils.py                               125      9     58      5    91%
splash/xvfb.py                                 25      6      6      3    71%
-----------------------------------------------------------------------------
TOTAL                                        6192    506   1707    206    90%

========================== slowest 50 test durations ===========================
7.70s call     splash/tests/test_render.py::RenderPngScalingAndCroppingTest::test_width_parameter_scales_the_image_tiled_raster
6.96s setup    splash/tests/test_argument_caching.py::RenderHtmlArgumentCachingTest::test_cache_url
5.52s call     splash/tests/test_argument_caching.py::RenderHtmlArgumentCachingTest::test_cache_url
4.20s setup    splash/tests/test_jupyter.py::SplashKernelTest::test_clear_output
4.06s call     splash/tests/test_execute.py::ResourceTimeoutTest::test_resource_timeout_attribute_priority
3.86s call     splash/tests/test_render.py::DisabledEnginesTest::test_browser_engines_all_enabled
3.18s call     splash/tests/test_execute.py::HarTest::test_har_reset_inprogress
3.09s call     splash/tests/test_render.py::RenderPngScalingAndCroppingTest::test_width_parameter_scales_the_image_tiled_vector
3.02s call     splash/tests/test_execute.py::IndexedDBTest::test_indexeddb_available2
2.80s call     splash/tests/test_execute.py::SandboxTest::test_infinite_loop_memory
2.51s call     splash/tests/test_execute.py::SandboxTest::test_infinite_loop
2.50s call     splash/tests/test_execute.py::SandboxTest::test_infinite_loop_toplevel
2.46s call     splash/tests/test_render_chromium.py::MetaRedirectTest::test_meta_redirect_slowload2_wait_more
2.38s call     splash/tests/test_har.py::RenderJsonHarTest::test_meta_redirect_slowload2_wait_more
2.37s call     splash/tests/test_execute_emulation.py::EmulatedRenderHarTest::test_meta_redirect_slowload2_wait_more
2.35s call     splash/tests/test_har.py::HarRenderTest::test_meta_redirect_slowload2_wait_more
2.34s call     splash/tests/test_jsonpost.py::HarRenderJsonPostTest::test_meta_redirect_slowload2_wait_more
2.33s call     splash/tests/test_execute_emulation.py::EmulatedMetaRedirectTest::test_meta_redirect_slowload2_wait_more
2.31s call     splash/tests/test_redirects.py::MetaRedirectTest::test_meta_redirect_slowload2_wait_more
2.20s call     splash/tests/test_render_chromium.py::MetaRedirectTest::test_meta_redirect_slowload2_wait
2.13s call     splash/tests/test_render_chromium.py::JsRedirectTest::test_redirect_to_non_existing
2.13s call     splash/tests/test_execute_emulation.py::EmulatedMetaRedirectTest::test_meta_redirect_slowload2_wait
2.12s call     splash/tests/test_render_chromium.py::MetaRedirectTest::test_meta_redirect_slowload2
2.12s call     splash/tests/test_redirects.py::MetaRedirectTest::test_meta_redirect_slowload2_wait
2.05s call     splash/tests/test_execute.py::WaitTest::test_wait_onerror_nocancel
2.05s call     splash/tests/test_redirects.py::MetaRedirectTest::test_meta_redirect_slowload2
2.05s call     splash/tests/test_execute.py::ResourceTimeoutTest::test_resource_timeout_zero
2.03s call     splash/tests/test_execute_emulation.py::EmulatedMetaRedirectTest::test_meta_redirect_slowload2
2.00s call     splash/tests/test_render.py::RenderVectorPngTest::test_very_long_green_page
1.99s call     splash/tests/test_execute_emulation.py::EmulatedRenderPngTest::test_very_long_green_page
1.96s call     splash/tests/test_execute.py::ErrorsTest::test_return_coroutine_nosandbox
1.95s call     splash/tests/test_render.py::RenderPngTest::test_very_long_green_page
1.71s call     splash/tests/test_request_filters.py::AllowedSchemesTest::test_disable_browser_caches
1.71s call     splash/tests/test_render.py::DisabledEnginesTest::test_browser_engines_webkit_disabled
1.70s call     splash/tests/test_client_disconnects.py::StopProcessingTest::test_js_timer_aborted
1.70s call     splash/tests/test_client_disconnects.py::StopProcessingTest::test_call_later_stopped
1.70s call     splash/tests/test_client_disconnects.py::StopProcessingTest::test_js_timer
1.70s call     splash/tests/test_client_disconnects.py::StopProcessingTest::test_wait_timer_stopped_after_request_finished
1.52s call     splash/tests/test_render_chromium.py::ChromiumRenderPngTest::test_wait
1.46s call     splash/tests/test_request_filters.py::DefaultFiltersTest::test_default_works
1.44s call     splash/tests/test_proxy.py::HtmlProxyDefaultProfileTest::test_default_profile_works
1.41s setup    splash/tests/test_client_disconnects.py::StopProcessingTest::test_call_later_stopped
1.37s call     splash/tests/test_execute.py::DisableScriptsTest::test_nolua
1.34s call     splash/tests/test_execute.py::SandboxTest::test_disable_sandbox
1.32s call     splash/tests/test_execute_emulation.py::EmulatedRenderPngTest::test_wait
1.30s call     splash/tests/test_request_filters.py::DefaultFiltersTest::test_testing_setup
1.28s call     splash/tests/test_render.py::RenderVectorPngTest::test_wait
1.26s call     splash/tests/test_proxy.py::HtmlProxyDefaultProfileTest::test_ts_setup
1.24s call     splash/tests/test_render.py::RenderPngTest::test_wait
1.23s call     splash/tests/test_execute_element.py::HTMLElementTest::test_send_text
= 1 failed, 1364 passed, 19 skipped, 57 xfailed, 11 xpassed, 3 warnings in 299.82s (0:04:59) =

```