### PR TITLE
Workaround for #1003

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 COPY --from=qt-downloader /tmp/qt-installer.run /tmp/
 
+ARG DISPLAY
+
 COPY dockerfiles/splash/qt-installer-noninteractive.qs /tmp/script.qs
 COPY dockerfiles/splash/run-qt-installer.sh /tmp/run-qt-installer.sh
 RUN /tmp/run-qt-installer.sh /tmp/qt-installer.run /tmp/script.qs

--- a/dockerfiles/splash/run-qt-installer.sh
+++ b/dockerfiles/splash/run-qt-installer.sh
@@ -2,8 +2,14 @@
 # XXX: if qt version is changed, Dockerfile should be updated,
 # as well as qt-installer-noninteractive.qs script.
 
+if [ -z ${DISPLAY+x} ]; then
+	command="xvfb-run $1"
+else
+	command="$1"
+fi
+
 chmod +x "$1" && \
-http_proxy="http://localhost:8080" https_proxy="http://localhost:8080" xvfb-run "$1" --script "$2" \
+http_proxy="http://localhost:8080" https_proxy="http://localhost:8080" $command --script "$2" \
     | egrep -v '\[[0-9]+\] Warning: (Unsupported screen format)|((QPainter|QWidget))' && \
 ls /opt/qt-5.13/ && \
 #    cat /opt/qt-5.13/InstallationLog.txt && \

--- a/dockerfiles/splash/run-qt-installer.sh
+++ b/dockerfiles/splash/run-qt-installer.sh
@@ -3,7 +3,7 @@
 # as well as qt-installer-noninteractive.qs script.
 
 chmod +x "$1" && \
-xvfb-run "$1" --script "$2" \
+http_proxy="http://localhost:8080" https_proxy="http://localhost:8080" xvfb-run "$1" --script "$2" \
     | egrep -v '\[[0-9]+\] Warning: (Unsupported screen format)|((QPainter|QWidget))' && \
 ls /opt/qt-5.13/ && \
 #    cat /opt/qt-5.13/InstallationLog.txt && \


### PR DESCRIPTION
By disabling the QT installers internet access login details are no longer required.

To achieve this I have had to split the build process up slightly as shown by the changes to the travis file.

Fixes #1003