### PR TITLE
Upgrade various QT components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ RUN /tmp/download-qt-installer.sh /tmp/qt-installer.run
 
 # =====================
 #
-#FROM byrnedo/alpine-curl as qtwebkit-source-downloader
-#COPY dockerfiles/splash/download-qtwebkit-source.sh /tmp/download-qtwebkit-source.sh
-#RUN /tmp/download-qtwebkit-source.sh /tmp/qtwebkit.tar.xz
+# FROM byrnedo/alpine-curl as qtwebkit-source-downloader
+# COPY dockerfiles/splash/download-qtwebkit-source.sh /tmp/download-qtwebkit-source.sh
+# RUN /tmp/download-qtwebkit-source.sh /tmp/qtwebkit.tar
 
 # =====================
 
@@ -57,25 +57,25 @@ COPY dockerfiles/splash/run-qt-installer.sh /tmp/run-qt-installer.sh
 RUN /tmp/run-qt-installer.sh /tmp/qt-installer.run /tmp/script.qs
 
 # XXX: this needs to be updated if Qt is updated
-ENV PATH="/opt/qt-5.13/5.13.1/gcc_64/bin:${PATH}"
+ENV PATH="/opt/qt-5.14/5.14.1/gcc_64/bin:${PATH}"
 
-# install qtwebkit
+#install qtwebkit
 COPY --from=qtwebkit-downloader /tmp/qtwebkit.7z /tmp/
 COPY dockerfiles/splash/install-qtwebkit.sh /tmp/install-qtwebkit.sh
 RUN /tmp/install-qtwebkit.sh /tmp/qtwebkit.7z
 
 # =====================
 
-#FROM qtbuilder as qtwebkitbuilder
-#COPY --from=qtwebkit-downloader /tmp/qtwebkit.tar.xz /tmp/
-#
-#COPY dockerfiles/splash/install-qtwebkit-build-deps.sh /tmp/install-qtwebkit-build-deps.sh
-#RUN /tmp/install-qtwebkit-build-deps.sh
-#
-#COPY dockerfiles/splash/build-qtwebkit.sh /tmp/build-qtwebkit.sh
-#RUN /tmp/build-qtwebkit.sh /tmp/qtwebkit.tar.xz
+# FROM qtbuilder as qtwebkitbuilder
+# COPY --from=qtwebkit-source-downloader /tmp/qtwebkit.tar /tmp/
 
-# =====================
+# COPY dockerfiles/splash/install-qtwebkit-build-deps.sh /tmp/install-qtwebkit-build-deps.sh
+# RUN /tmp/install-qtwebkit-build-deps.sh
+
+# COPY dockerfiles/splash/build-qtwebkit.sh /tmp/build-qtwebkit.sh
+# RUN /tmp/build-qtwebkit.sh /tmp/qtwebkit.tar
+
+# # =====================
 
 FROM qtbase as splash-base
 
@@ -83,12 +83,15 @@ COPY dockerfiles/splash/install-system-splash-deps.sh /tmp/install-system-splash
 RUN /tmp/install-system-splash-deps.sh
 
 # XXX: this needs to be updated if Qt is updated
-COPY --from=qtbuilder /opt/qt-5.13/5.13.1/gcc_64 /opt/qt-5.13/5.13.1/gcc_64
-#RUN ls -l /opt/qt-5.13/5.13.0/gcc_64/lib
-ENV PATH="/opt/qt-5.13/5.13.1/gcc_64/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/qt-5.13/5.13.1/gcc_64/lib:$LD_LIBRARY_PATH"
+# COPY --from=qtwebkitbuilder /opt/qt-5.14/5.14.1/gcc_64 /opt/qt-5.14/5.14.1/gcc_64
+COPY --from=qtbuilder /opt/qt-5.14/5.14.1/gcc_64 /opt/qt-5.14/5.14.1/gcc_64
 
-# =====================
+# RUN ls -l /opt/qt-5.14/5.14.0/gcc_64/lib
+
+ENV PATH="/opt/qt-5.14/5.14.1/gcc_64/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/qt-5.14/5.14.1/gcc_64/lib:$LD_LIBRARY_PATH"
+
+ # =====================
 
 FROM splash-base as qt5-builder
 
@@ -121,7 +124,6 @@ ENV PYTHONPATH $PYTHONPATH:/app
 RUN groupadd -r splash && useradd --no-log-init --create-home -r -g splash splash
 RUN chown -R splash:splash /app
 USER splash:splash
-
 
 VOLUME [ \
     "/etc/splash/proxy-profiles", \

--- a/dockerfiles/splash/download-pyqt5.sh
+++ b/dockerfiles/splash/download-pyqt5.sh
@@ -2,8 +2,8 @@
 # XXX: these URLs needs to be replaced with sourceforge in future,
 # because riverbank tend to remove old releases.
 SIP="https://www.riverbankcomputing.com/static/Downloads/sip/4.19.19/sip-4.19.19.tar.gz"
-PYQT5="https://www.riverbankcomputing.com/static/Downloads/PyQt5/5.13.1/PyQt5_gpl-5.13.1.tar.gz"
-WEBENGINE="https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/5.13.1/PyQtWebEngine_gpl-5.13.1.tar.gz"
+PYQT5="https://www.riverbankcomputing.com/static/Downloads/PyQt5/5.13.2/PyQt5-5.13.2.tar.gz"
+WEBENGINE="https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/5.13.2/PyQtWebEngine-5.13.2.tar.gz"
 
 curl -L -o "$1" ${SIP} && \
 curl -L -o "$2" ${PYQT5} && \

--- a/dockerfiles/splash/download-qt-installer.sh
+++ b/dockerfiles/splash/download-qt-installer.sh
@@ -2,6 +2,6 @@
 
 # XXX: if qt version is changed, Dockerfile should be updated,
 # as well as qt-installer-noninteractive.qs script.
-URL="http://download.qt.io/official_releases/qt/5.13/5.13.1/qt-opensource-linux-x64-5.13.1.run"
+URL="http://download.qt.io/official_releases/qt/5.14/5.14.1/qt-opensource-linux-x64-5.14.1.run"
 
 curl -L -o "$1" ${URL}

--- a/dockerfiles/splash/download-qtwebkit-source.sh
+++ b/dockerfiles/splash/download-qtwebkit-source.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-URL="https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-5.212.0-alpha3/qtwebkit-5.212.0-alpha3.tar.xz"
+URL="https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-5.212.0-alpha4/qtwebkit-5.212.0-alpha4.tar.xz"
 curl -L -o "$1" ${URL}

--- a/dockerfiles/splash/download-qtwebkit.sh
+++ b/dockerfiles/splash/download-qtwebkit.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-URL="https://download.qt.io/snapshots/ci/qtwebkit/5.212/1570542016/qtwebkit/qtwebkit-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z"
+URL="https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-5.212.0-alpha4/qtwebkit-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z"
 curl -L -o "$1" ${URL}

--- a/dockerfiles/splash/qt-installer-noninteractive.qs
+++ b/dockerfiles/splash/qt-installer-noninteractive.qs
@@ -24,15 +24,15 @@ Controller.prototype.IntroductionPageCallback = function() {
 
 Controller.prototype.TargetDirectoryPageCallback = function()
 {
-    gui.currentPageWidget().TargetDirectoryLineEdit.setText("/opt/qt-5.13");
+    gui.currentPageWidget().TargetDirectoryLineEdit.setText("/opt/qt-5.14");
     gui.clickButton(buttons.NextButton);
 }
 
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var components = [
-      "qt.qt5.5131.gcc_64",
-      "qt.qt5.5131.qtwebengine",
-      "qt.qt5.5131.qtnetworkauth",
+      "qt.qt5.5141.gcc_64",
+      "qt.qt5.5141.qtwebengine",
+      "qt.qt5.5141.qtnetworkauth",
     ]
     console.log("Select components");
     var widget = gui.currentPageWidget();

--- a/dockerfiles/splash/run-qt-installer.sh
+++ b/dockerfiles/splash/run-qt-installer.sh
@@ -9,8 +9,8 @@ else
 fi
 
 chmod +x "$1" && \
-http_proxy="http://localhost:8080" https_proxy="http://localhost:8080" $command --script "$2" \
+http_proxy="http://localhost:8080" https_proxy="http://localhost:8080" $command --script $2 \
     | egrep -v '\[[0-9]+\] Warning: (Unsupported screen format)|((QPainter|QWidget))' && \
-ls /opt/qt-5.13/ && \
-#    cat /opt/qt-5.13/InstallationLog.txt && \
-cat /opt/qt-5.13/components.xml
+ls /opt/qt-5.14/ && \
+#    cat /opt/qt-5.14/InstallationLog.txt && \
+cat /opt/qt-5.14/components.xml


### PR DESCRIPTION
Upgrade to QT 5.14.1
Upgrade PyQT to 5.13.2 (They've dropped GPL in the filename, I don't see any mention of license changes)
Upgrade PyQTWebengine to 5.13.2 (They've dropped GPL in the filename, I don't see any mention of license changes)
Upgrade QtWebkit to 5.212.0 Alpha 4