### PR TITLE
Remove encoding parameter from json.load for Python 3.9 compatibility.

### DIFF
--- a/splash/kernel/inspections.py
+++ b/splash/kernel/inspections.py
@@ -94,7 +94,7 @@ class _SplashDocs(object):
         for name in files:
             full_name = os.path.join(folder, name)
             with open(full_name, "rb") as f:
-                info = json.loads(f.read().decode('utf-8'), encoding='utf8')
+                info = json.loads(f.read().decode('utf-8'))
             self.info.update(info)
 
     def __getitem__(self, item):

--- a/splash/render_options.py
+++ b/splash/render_options.py
@@ -46,7 +46,7 @@ class RenderOptions(object):
                 if b'application/json' in content_type:
                     try:
                         content = request.content.read().decode('utf-8')
-                        data.update(json.loads(content, encoding='utf8'))
+                        data.update(json.loads(content))
                     except ValueError as e:
                         raise BadOption({
                             'type': 'invalid_json',


### PR DESCRIPTION
Fixes #1052 

Signed-off-by: Karthikeyan Singaravelan <tir.karthi@gmail.com>