### PR TITLE
Allow overriding target test files in ‘docker run’ calls

### DIFF
--- a/dockerfiles/tests/Dockerfile
+++ b/dockerfiles/tests/Dockerfile
@@ -33,3 +33,4 @@ RUN find . -name \*.pyc -delete
 RUN chown -R splash:splash /app
 USER splash:splash
 ENTRYPOINT ["/app/dockerfiles/tests/runtests.sh"]
+CMD ["splash"]

--- a/dockerfiles/tests/runtests.sh
+++ b/dockerfiles/tests/runtests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-py.test --cov=splash --doctest-modules --durations=50 splash "$@" && \
+py.test --cov=splash --doctest-modules --durations=50 "$@" && \
 if [ -n "${TRAVIS}" ]; then
     codecov
 fi;


### PR DESCRIPTION
After this change, when running the tests locally, you can for example append `tests/test_proxy.py` to the `docker run` command to run only the tests defined in that file.