### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,6 @@ jobs:
           tags: splash-tests
       -
         name: Run tests
-        run: | 
+        shell: 'script --return --quiet --command "bash {0}"'
+        run: |
           docker run -it splash-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,5 @@ jobs:
           tags: splash-tests
       -
         name: Run tests
-        shell: 'script --return --quiet --command "bash {0}"'
         run: | 
           docker run -it splash-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,4 +25,4 @@ jobs:
         name: Run tests and Codecov
         shell: 'script --return --quiet --command "bash {0}"'
         run: |
-          docker run --env CI=${CI} -it splash-tests
+          docker run -v $(pwd)/.git:/app/.git --env CI=${CI} -it splash-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,4 +25,4 @@ jobs:
         name: Run tests and Codecov
         shell: 'script --return --quiet --command "bash {0}"'
         run: |
-          docker run --env CI='true' -it splash-tests
+          docker run --env CI=${CI} -it splash-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,4 +24,5 @@ jobs:
       -
         name: Run tests
         shell: 'script --return --quiet --command "bash {0}"'
-        run: docker run -it splash-tests
+        run: | 
+          docker run -it splash-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
           context: dockerfiles/tests
           tags: splash-tests
       -
-        name: Run tests and Codecov
+        name: Run tests
         shell: 'script --return --quiet --command "bash {0}"'
-        run: |
-          docker run -v $(pwd)/.git:/app/.git --env CI=${CI} -it splash-tests
+        run: docker run -it splash-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2.3.4
+      -
+        name: Build base image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          tags: splash
+      -
+        name: Build tests image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: dockerfiles/tests
+          tags: splash-tests
+      -
+        name: Run tests and Codecov
+        shell: 'script --return --quiet --command "bash {0}"'
+        run: |
+          docker run --env CI='true' -it splash-tests

--- a/dockerfiles/splash/install-python-splash-deps.sh
+++ b/dockerfiles/splash/install-python-splash-deps.sh
@@ -3,7 +3,7 @@ _PYTHON=python3
 
 install_python_deps () {
     # Install python-level dependencies.
-    ${_PYTHON} -m pip install -U pip setuptools six && \
+    ${_PYTHON} -m pip install -U pip setuptools==57.5.0 six && \
     ${_PYTHON} -m pip install \
         qt5reactor==0.5 \
         psutil==5.0.0 \

--- a/dockerfiles/tests/runtests.sh
+++ b/dockerfiles/tests/runtests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 py.test --cov=splash --doctest-modules --durations=50 "$@" && \
-if [ -n "${TRAVIS}" ]; then
+if [ -n "${CI}" ]; then
     codecov
 fi;

--- a/dockerfiles/tests/runtests.sh
+++ b/dockerfiles/tests/runtests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 py.test --cov=splash --doctest-modules --durations=50 "$@" && \
-if [ -n "${CI}" ]; then
-    codecov
-fi;
+#if [ -n "${CI}" ]; then
+#    codecov
+#fi;

--- a/dockerfiles/tests/runtests.sh
+++ b/dockerfiles/tests/runtests.sh
@@ -1,5 +1,2 @@
 #!/usr/bin/env bash
-py.test --cov=splash --doctest-modules --durations=50 "$@" && \
-#if [ -n "${CI}" ]; then
-#    codecov
-#fi;
+py.test --cov=splash --doctest-modules --durations=50 "$@"


### PR DESCRIPTION
I pinned the `setuptools` version to `57.5.0`, because `58.0.0` have a [breaking change](https://github.com/pypa/setuptools/blob/main/CHANGES.rst#breaking-changes):
- #2086: Removed support for 2to3 during builds. Projects should port to a unified codebase or pin to an older version of Setuptools using PEP 518 build-requires.

That make `funcparserlib` dependency not work because it use `use_2to3`. 

Changed the `CIRCLE_CI` env to `CI` that is the variable that [Github Actions](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) use.

Used a [dirty hack](https://github.com/actions/runner/issues/241#issuecomment-924327172) in order to make TTY work. Explanation [here](https://explainshell.com/explain?cmd=script+--return+--quiet+--command+%22bash+%7B0%7D%22)

For some unknown reason i could not make it Codecov work in my tests.

I also have the action to publish image to docker repository but i not add to this PR (But i can if is needed).