### PR TITLE
Fix build failing due to multistage docker COPY issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,7 @@ RUN /tmp/install-python-splash-deps.sh
 # FIXME: use virtualenv
 COPY --from=qt5-builder /usr/lib/python3/dist-packages /usr/lib/python3/dist-packages
 COPY --from=qt5-builder /usr/local/lib/python3.6/dist-packages /usr/local/lib/python3.6/dist-packages
-
+RUN true
 COPY . /app
 RUN pip3 install /app
 ENV PYTHONPATH $PYTHONPATH:/app


### PR DESCRIPTION
The current Dockerfile fails on build with error "**Docker: failed to export image: failed to create image: failed to get layer**"
Adding "**_`RUN true`_**" fixes the issue.
See issue resolution here: 
https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer